### PR TITLE
Move localised strings to a bundle.

### DIFF
--- a/TOCropViewController.podspec
+++ b/TOCropViewController.podspec
@@ -9,6 +9,8 @@ Pod::Spec.new do |s|
   s.platform = :ios, '7.0'
 
   s.source_files = 'TOCropViewController/**/*.{h,m}'
-  s.resources = 'TOCropViewController/*.lproj'
+  s.resource_bundles = {
+    'TOCropViewControllerBundle' => ['TOCropViewController/*.lproj']
+  }
   s.requires_arc = true
 end

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -256,10 +256,19 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
     BOOL verticalCropBox = self.cropView.cropBoxAspectRatioIsPortrait;
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil
                                                              delegate:self
-                                                    cancelButtonTitle:NSLocalizedStringFromTable(@"Cancel", @"TOCropViewControllerLocalizable", nil)
+                                                    cancelButtonTitle:NSLocalizedStringFromTableInBundle(@"Cancel",
+                                                                                                         @"TOCropViewControllerLocalizable",
+                                                                                                         [NSBundle bundleForClass:[self class]],
+                                                                                                         nil)
                                                destructiveButtonTitle:nil
-                                                    otherButtonTitles:NSLocalizedStringFromTable(@"Original", @"TOCropViewControllerLocalizable", nil),
-                                                                      NSLocalizedStringFromTable(@"Square", @"TOCropViewControllerLocalizable", nil),
+                                                    otherButtonTitles:NSLocalizedStringFromTableInBundle(@"Original",
+                                                                                                         @"TOCropViewControllerLocalizable",
+                                                                                                         [NSBundle bundleForClass:[self class]],
+                                                                                                         nil),
+                                                                      NSLocalizedStringFromTableInBundle(@"Square",
+                                                                                                         @"TOCropViewControllerLocalizable",
+                                                                                                         [NSBundle bundleForClass:[self class]],
+                                                                                                         nil),
                                                                       verticalCropBox ? @"2:3" : @"3:2",
                                                                       verticalCropBox ? @"3:5" : @"5:3",
                                                                       verticalCropBox ? @"3:4" : @"4:3",

--- a/TOCropViewController/Views/TOCropToolbar.m
+++ b/TOCropViewController/Views/TOCropToolbar.m
@@ -61,7 +61,11 @@
     
     _doneTextButton = [UIButton buttonWithType:UIButtonTypeSystem];
     _doneTextButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
-    [_doneTextButton setTitle:NSLocalizedStringFromTable(@"Done", @"TOCropViewControllerLocalizable", nil) forState:UIControlStateNormal];
+    [_doneTextButton setTitle:NSLocalizedStringFromTableInBundle(@"Done",
+                                                                 @"TOCropViewControllerLocalizable",
+                                                                 [NSBundle bundleForClass:[self class]],
+                                                                 nil)
+                     forState:UIControlStateNormal];
     [_doneTextButton setTitleColor:[UIColor colorWithRed:1.0f green:0.8f blue:0.0f alpha:1.0f] forState:UIControlStateNormal];
     [_doneTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f]];
     [_doneTextButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
@@ -75,7 +79,11 @@
     
     _cancelTextButton = [UIButton buttonWithType:UIButtonTypeSystem];
     _cancelTextButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-    [_cancelTextButton setTitle:NSLocalizedStringFromTable(@"Cancel", @"TOCropViewControllerLocalizable", nil) forState:UIControlStateNormal];
+    [_cancelTextButton setTitle:NSLocalizedStringFromTableInBundle(@"Cancel",
+                                                                   @"TOCropViewControllerLocalizable",
+                                                                   [NSBundle bundleForClass:[self class]],
+                                                                   nil)
+                       forState:UIControlStateNormal];
     [_cancelTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f]];
     [_cancelTextButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
     [self addSubview:_cancelTextButton];


### PR DESCRIPTION
TOCropViewController attaches localised strings in a wrong manner. This results in applications being listed on App Store as supporting all the languages that TOCropViewControllers supports. (see similar issue with FormatterKit: https://github.com/mattt/FormatterKit/issues/88)

This PR fixes it by moving the localised strings to a bundle (according to CocoaPods docs this is the recommended technique).