### PR TITLE
Added property for fixedAspectRatio.

### DIFF
--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -95,6 +95,12 @@
  */
 @property (nonatomic, strong) NSArray *excludedActivityTypes;
 
+/**
+ If fixedAspectRatio is set (to non-CGSizeZero) it will automatically hide the clamp aspect control and rotation control. Reset stays.
+ */
+@property (nonatomic, assign) CGSize fixedAspectRatio;
+
+
 ///------------------------------------------------
 /// @name Object Creation
 ///------------------------------------------------

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -69,7 +69,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
     if (self) {
         self.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
         self.modalPresentationStyle = UIModalPresentationFullScreen;
-        
+        _fixedAspectRatio = CGSizeZero;
         _transitionController = [[TOCropViewControllerTransitioning alloc] init];
         _image = image;
     }
@@ -111,6 +111,12 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
     if ([UIApplication sharedApplication].statusBarHidden == NO) {
         self.inTransition = YES;
         [self setNeedsStatusBarAppearanceUpdate];
+    }
+    
+    if (! CGSizeEqualToSize(CGSizeZero,self.fixedAspectRatio)) {
+        self.toolbar.rotateButtonHidden = YES;
+        self.toolbar.clampButtonHidden = YES;
+        [self.cropView setAspectLockEnabledWithAspectRatio:self.fixedAspectRatio animated:YES];
     }
 }
 

--- a/TOCropViewController/Views/TOCropToolbar.h
+++ b/TOCropViewController/Views/TOCropToolbar.h
@@ -32,6 +32,7 @@
 @property (nonatomic, copy) void (^resetButtonTapped)(void);
 
 /* Aspect ratio button settings */
+@property (nonatomic, assign) BOOL clampButtonHidden;
 @property (nonatomic, assign) BOOL clampButtonGlowing;
 @property (nonatomic, readonly) CGRect clampButtonFrame;
 

--- a/TOCropViewController/Views/TOCropToolbar.m
+++ b/TOCropViewController/Views/TOCropToolbar.m
@@ -129,6 +129,7 @@
     self.doneTextButton.hidden   = (verticalLayout);
     
     self.rotateButton.hidden = self.rotateButtonHidden;
+    self.clampButton.hidden = self.clampButtonHidden;
     
     if (verticalLayout == NO) {
         CGRect frame = CGRectZero;

--- a/TOCropViewController/Views/TOCropView.h
+++ b/TOCropViewController/Views/TOCropView.h
@@ -53,6 +53,8 @@
  */
 @property (nonatomic, readonly) CGRect cropBoxFrame;
 
+@property (nonatomic, assign) CGSize originalCropBoxSize; /* Save the original crop box size so we can tell when the content has been edited */
+
 /**
  The frame of the entire image in the backing scroll view
  */

--- a/TOCropViewController/Views/TOCropView.m
+++ b/TOCropViewController/Views/TOCropView.m
@@ -82,7 +82,8 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
 @property (nonatomic, assign) BOOL rotateAnimationInProgress;   /* Disallow any input while the rotation animation is playing */
 
 /* Reset state data */
-@property (nonatomic, assign) CGSize originalCropBoxSize; /* Save the original crop box size so we can tell when the content has been edited */
+// Made public:
+// @property (nonatomic, assign) CGSize originalCropBoxSize; /* Save the original crop box size so we can tell when the content has been edited */
 @property (nonatomic, assign, readwrite) BOOL canReset;
 
 - (void)setup;
@@ -993,6 +994,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
             self.scrollView.zoomScale = self.scrollView.minimumZoomScale;
         [self moveCroppedContentToCenterAnimated:NO];
     } completion:nil];
+    self.originalCropBoxSize = self.cropBoxFrame.size;
 }
 
 - (void)rotateImageNinetyDegreesAnimated:(BOOL)animated

--- a/TOCropViewControllerExample.xcodeproj/project.pbxproj
+++ b/TOCropViewControllerExample.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 					};
 					223424691ABBC0CD00BBC2B1 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 6LF3GMKZAB;
+						DevelopmentTeam = 33U326FCC6;
 					};
 				};
 			};
@@ -453,7 +453,8 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Paul Jacobs (R222AB8GY8)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Paul Jacobs (R222AB8GY8)";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -496,7 +497,8 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Paul Jacobs (R222AB8GY8)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Paul Jacobs (R222AB8GY8)";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/TOCropViewControllerExample.xcodeproj/project.xcworkspace/xcshareddata/TOCropViewControllerExample.xccheckout
+++ b/TOCropViewControllerExample.xcodeproj/project.xcworkspace/xcshareddata/TOCropViewControllerExample.xccheckout
@@ -7,21 +7,21 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>2D90AB17-71D2-4E13-9F5B-7AFB673BBD9E</string>
 	<key>IDESourceControlProjectName</key>
-	<string>project</string>
+	<string>TOCropViewControllerExample</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>EBF9236F7ED7963EA21B6A80B0DA4EDCCFA2B7DF</key>
-		<string>https://github.com/TimOliver/TOCropViewController.git</string>
+		<string>https://github.com/codehearted/TOCropViewController.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>TOCropViewControllerExample.xcodeproj/project.xcworkspace</string>
+	<string>TOCropViewControllerExample.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>EBF9236F7ED7963EA21B6A80B0DA4EDCCFA2B7DF</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/TimOliver/TOCropViewController.git</string>
+	<string>https://github.com/codehearted/TOCropViewController.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>

--- a/TOCropViewControllerExample/ViewController.m
+++ b/TOCropViewControllerExample/ViewController.m
@@ -121,6 +121,7 @@
         self.image = image;
         TOCropViewController *cropController = [[TOCropViewController alloc] initWithImage:image];
         cropController.delegate = self;
+        cropController.fixedAspectRatio = CGSizeMake(320, 120);
         [self presentViewController:cropController animated:YES completion:nil];
     }];
 }
@@ -135,6 +136,7 @@
 {
     TOCropViewController *cropController = [[TOCropViewController alloc] initWithImage:self.image];
     cropController.delegate = self;
+    cropController.fixedAspectRatio = CGSizeMake(320, 120);
     [self presentViewController:cropController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
When fixedAspectRatio is set, it will not let the user choose a different ratio and removes the clamp and rotate controls as each of them changes the aspect ratio. Reset is left in place but updated so that when fixedAspectRatio is in effect, it will no longer reset the aspect ratio clamp state and thus remains at the fixed ratio.