### PR TITLE
defaultAspectRatio and lockedAspectRatio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+#Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build

--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -22,6 +22,17 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
+    TOCropViewControllerAspectRatioOriginal,
+    TOCropViewControllerAspectRatioSquare,
+    TOCropViewControllerAspectRatio3x2,
+    TOCropViewControllerAspectRatio5x3,
+    TOCropViewControllerAspectRatio4x3,
+    TOCropViewControllerAspectRatio5x4,
+    TOCropViewControllerAspectRatio7x5,
+    TOCropViewControllerAspectRatio16x9
+};
+
 @class TOCropViewController;
 
 ///------------------------------------------------
@@ -72,6 +83,11 @@
  If true, when the user hits 'Done', a UIActivityController will appear before the view controller ends
  */
 @property (nonatomic, assign) BOOL showActivitySheetOnDone;
+
+/**
+ The default aspect ratio for the crop view, the default value is TOCropViewControllerAspectRatioOriginal.
+ */
+@property (nonatomic, assign) TOCropViewControllerAspectRatio defaultAspectRatio;
 
 /**
  If performing a transition animation, this block can be used to set up any view states just before the animation begins

--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -90,6 +90,11 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
 @property (nonatomic, assign) TOCropViewControllerAspectRatio defaultAspectRatio;
 
 /**
+ If true, the aspect ratio will be locked to the defaultAspectRatio. And, the aspect ratio button won't appear on the toolbar.
+ */
+@property (nonatomic, assign) BOOL lockedAspectRatio;
+
+/**
  If performing a transition animation, this block can be used to set up any view states just before the animation begins
  */
 @property (nonatomic, copy) void (^prepareForTransitionHandler)(void);

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -28,17 +28,6 @@
 #import "UIImage+CropRotate.h"
 #import "TOCroppedImageAttributes.h"
 
-typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
-    TOCropViewControllerAspectRatioOriginal,
-    TOCropViewControllerAspectRatioSquare,
-    TOCropViewControllerAspectRatio3x2,
-    TOCropViewControllerAspectRatio5x3,
-    TOCropViewControllerAspectRatio4x3,
-    TOCropViewControllerAspectRatio5x4,
-    TOCropViewControllerAspectRatio7x5,
-    TOCropViewControllerAspectRatio16x9
-};
-
 @interface TOCropViewController () <UIActionSheetDelegate, UIViewControllerTransitioningDelegate, TOCropViewDelegate>
 
 @property (nonatomic, readwrite) UIImage *image;
@@ -76,6 +65,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
         
         _transitionController = [[TOCropViewControllerTransitioning alloc] init];
         _image = image;
+        _defaultAspectRatio = TOCropViewControllerAspectRatioOriginal;
     }
     
     return self;
@@ -106,6 +96,10 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
     self.transitioningDelegate = self;
     
     self.view.backgroundColor = self.cropView.backgroundColor;
+
+    if (self.defaultAspectRatio != TOCropViewControllerAspectRatioOriginal) {
+        [self setAspectRatio:self.defaultAspectRatio animated:NO];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -294,9 +288,14 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
+    [self setAspectRatio:(TOCropViewControllerAspectRatio)buttonIndex animated:YES];
+}
+
+- (void)setAspectRatio:(TOCropViewControllerAspectRatio)aspectRatioSize animated:(BOOL)animated
+{
     CGSize aspectRatio = CGSizeZero;
     
-    switch (buttonIndex) {
+    switch (aspectRatioSize) {
         case TOCropViewControllerAspectRatioOriginal:
             aspectRatio = CGSizeZero;
             break;
@@ -321,8 +320,6 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
         case TOCropViewControllerAspectRatio16x9:
             aspectRatio = CGSizeMake(16.0f, 9.0f);
             break;
-        default:
-            return;
     }
     
     if (self.cropView.cropBoxAspectRatioIsPortrait) {
@@ -331,7 +328,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatio) {
         aspectRatio.height = width;
     }
     
-    [self.cropView setAspectLockEnabledWithAspectRatio:aspectRatio animated:YES];
+    [self.cropView setAspectLockEnabledWithAspectRatio:aspectRatio animated:animated];
     self.toolbar.clampButtonGlowing = YES;
 }
 

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -65,7 +65,9 @@
         
         _transitionController = [[TOCropViewControllerTransitioning alloc] init];
         _image = image;
+        
         _defaultAspectRatio = TOCropViewControllerAspectRatioOriginal;
+        _lockedAspectRatio = NO;
     }
     
     return self;
@@ -83,6 +85,7 @@
     [self.view addSubview:self.cropView];
     
     self.toolbar = [[TOCropToolbar alloc] initWithFrame:CGRectZero];
+    self.toolbar.clampButtonHidden = self.lockedAspectRatio;
     self.toolbar.frame = [self frameForToolBarWithVerticalLayout:CGRectGetWidth(self.view.bounds) < CGRectGetHeight(self.view.bounds)];
     [self.view addSubview:self.toolbar];
     
@@ -240,8 +243,13 @@
 - (void)resetCropViewLayout
 {
     [self.cropView resetLayoutToDefaultAnimated:YES];
-    self.cropView.aspectLockEnabled = NO;
-    self.toolbar.clampButtonGlowing = NO;
+    
+    if (self.lockedAspectRatio) {
+        [self setAspectRatio:self.defaultAspectRatio animated:NO];
+    } else {
+        self.cropView.aspectLockEnabled = NO;
+        self.toolbar.clampButtonGlowing = NO;
+    }
 }
 
 #pragma mark - Aspect Ratio Handling -
@@ -335,6 +343,9 @@
 - (void)rotateCropView
 {
     [self.cropView rotateImageNinetyDegreesAnimated:YES];
+    if (self.lockedAspectRatio) {
+        [self setAspectRatio:self.defaultAspectRatio animated:NO];
+    }
 }
 
 #pragma mark - Crop View Delegates -

--- a/TOCropViewController/Views/TOCropToolbar.h
+++ b/TOCropViewController/Views/TOCropToolbar.h
@@ -32,6 +32,7 @@
 @property (nonatomic, copy) void (^resetButtonTapped)(void);
 
 /* Aspect ratio button settings */
+@property (nonatomic, assign) BOOL clampButtonHidden;
 @property (nonatomic, assign) BOOL clampButtonGlowing;
 @property (nonatomic, readonly) CGRect clampButtonFrame;
 

--- a/TOCropViewController/Views/TOCropToolbar.m
+++ b/TOCropViewController/Views/TOCropToolbar.m
@@ -127,9 +127,22 @@
     self.cancelTextButton.hidden = (verticalLayout);
     self.doneIconButton.hidden   = (!verticalLayout);
     self.doneTextButton.hidden   = (verticalLayout);
-    
+   
+    self.clampButton.hidden = self.clampButtonHidden;
     self.rotateButton.hidden = self.rotateButtonHidden;
-    
+   
+    CGFloat containerRectWidth = 165.0f;
+    NSInteger buttonCount = 3;
+    if (self.rotateButtonHidden && self.clampButtonHidden) {
+        buttonCount = 1;
+    }
+    else if (self.rotateButtonHidden || self.clampButtonHidden) {
+        buttonCount = 2;
+    }
+    CGFloat buttonWidth = floorf(containerRectWidth/buttonCount);
+   
+    CGRect containerRect;
+    CGRectEdge rectEdge;
     if (verticalLayout == NO) {
         CGRect frame = CGRectZero;
         frame.size.height = 44.0f;
@@ -140,25 +153,9 @@
         frame.origin.x = boundsSize.width - CGRectGetWidth(frame);
         self.doneTextButton.frame = frame;
         
-        CGRect containerRect = (CGRect){0,0,165.0f,44.0f};
+        containerRect = (CGRect){0,0,containerRectWidth,44.0f};
         containerRect.origin.x = (CGRectGetWidth(self.bounds) - (CGRectGetWidth(containerRect))) * 0.5f;
-        
-        CGRect buttonFrame = (CGRect){0,0,44.0f,44.0f};
-        
-        if (self.rotateButtonHidden) {
-            buttonFrame.origin.x = CGRectGetMinX(containerRect);
-            self.resetButton.frame = buttonFrame;
-        }
-        else {
-            buttonFrame.origin.x = CGRectGetMinX(containerRect);
-            self.rotateButton.frame = buttonFrame;
-            
-            buttonFrame.origin.x = CGRectGetMidX(containerRect) -  22.0f;
-            self.resetButton.frame = buttonFrame;
-        }
-        
-        buttonFrame.origin.x = CGRectGetMaxX(containerRect) - 44.0f;
-        self.clampButton.frame = buttonFrame;
+        rectEdge = CGRectMinXEdge;
     }
     else {
         CGRect frame = CGRectZero;
@@ -172,24 +169,22 @@
         frame.size.height = 44.0f;
         self.doneIconButton.frame = frame;
         
-        CGRect containerRect = (CGRect){0,0,44.0f,165.0f};
+        containerRect = (CGRect){0,0,44.0f,containerRectWidth};
         containerRect.origin.y = (CGRectGetHeight(self.bounds) - (CGRectGetHeight(containerRect))) * 0.5f;
-        
-        CGRect buttonFrame = (CGRect){0,0,44.0f,44.0f};
-        
-        if (self.rotateButtonHidden) {
-            buttonFrame.origin.y = CGRectGetMinY(containerRect);
-            self.resetButton.frame = buttonFrame;
-        }
-        else {
-            buttonFrame.origin.y = CGRectGetMinY(containerRect);
-            self.rotateButton.frame = buttonFrame;
-            
-            buttonFrame.origin.y = CGRectGetMidY(containerRect) -  22.0f;
-            self.resetButton.frame = buttonFrame;
-        }
+        rectEdge = CGRectMinYEdge;
+    }
 
-        buttonFrame.origin.y = CGRectGetMaxY(containerRect) - 44.0f;
+    CGRect buttonFrame;
+    if (!self.rotateButtonHidden) {
+        CGRectDivide(containerRect, &buttonFrame, &containerRect, buttonWidth, rectEdge);
+        self.rotateButton.frame = buttonFrame;
+    }
+    
+    CGRectDivide(containerRect, &buttonFrame, &containerRect, buttonWidth, rectEdge);
+    self.resetButton.frame = buttonFrame;
+    
+    if (!self.clampButtonHidden) {
+        CGRectDivide(containerRect, &buttonFrame, &containerRect, buttonWidth, rectEdge);
         self.clampButton.frame = buttonFrame;
     }
 }
@@ -219,6 +214,14 @@
 - (CGRect)clampButtonFrame
 {
     return self.clampButton.frame;
+}
+
+- (void)setClampButtonHidden:(BOOL)clampButtonHidden {
+    if (_clampButtonHidden == clampButtonHidden)
+        return;
+    
+    _clampButtonHidden = clampButtonHidden;
+    [self setNeedsLayout];
 }
 
 - (void)setClampButtonGlowing:(BOOL)clampButtonGlowing

--- a/TOCropViewControllerExample/ViewController.m
+++ b/TOCropViewControllerExample/ViewController.m
@@ -120,6 +120,7 @@
     [self dismissViewControllerAnimated:YES completion:^{
         self.image = image;
         TOCropViewController *cropController = [[TOCropViewController alloc] initWithImage:image];
+        cropController.defaultAspectRatio = TOCropViewControllerAspectRatioSquare;
         cropController.delegate = self;
         [self presentViewController:cropController animated:YES completion:nil];
     }];
@@ -134,6 +135,7 @@
 - (void)didTapImageView
 {
     TOCropViewController *cropController = [[TOCropViewController alloc] initWithImage:self.image];
+    cropController.defaultAspectRatio = TOCropViewControllerAspectRatioSquare;
     cropController.delegate = self;
     [self presentViewController:cropController animated:YES completion:nil];
 }

--- a/TOCropViewControllerExample/ViewController.m
+++ b/TOCropViewControllerExample/ViewController.m
@@ -121,6 +121,7 @@
         self.image = image;
         TOCropViewController *cropController = [[TOCropViewController alloc] initWithImage:image];
         cropController.defaultAspectRatio = TOCropViewControllerAspectRatioSquare;
+        cropController.lockedAspectRatio = YES;
         cropController.delegate = self;
         [self presentViewController:cropController animated:YES completion:nil];
     }];


### PR DESCRIPTION
I added two options `defaultAspectRatio` and `lockedAspectRatio` which behaviors you can see from the comments:

```
 /**
+ The default aspect ratio for the crop view, the default value is TOCropViewControllerAspectRatioOriginal.
+ */
+@property (nonatomic, assign) TOCropViewControllerAspectRatio defaultAspectRatio;
+
+/**
+ If true, the aspect ratio will be locked to the defaultAspectRatio. And, the aspect ratio button won't appear on the toolbar.
+ */
+@property (nonatomic, assign) BOOL lockedAspectRatio;
```

The only bug I am seeing now is with the reset button which isn't working as the old behavior that it should.