### PR TITLE
Hide aspect ratio button if 'lockedAspectRatio' is true

### DIFF
--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -387,6 +387,7 @@
     
     [self.cropView setAspectLockEnabledWithAspectRatio:aspectRatio animated:animated];
     self.toolbar.clampButtonGlowing = YES;
+    self.toolbar.clampButtonHidden = YES;
 }
 
 - (void)rotateCropView


### PR DESCRIPTION
Currently it's displayed and can be unlocked.