### PR TITLE
Fix -[NSString containsString:] crash.

### DIFF
--- a/TOCropViewController/Views/TOCropToolbar.m
+++ b/TOCropViewController/Views/TOCropToolbar.m
@@ -72,7 +72,7 @@
         self.reverseContentLayout = ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft);
     }
     else {
-        self.reverseContentLayout = [[[NSLocale preferredLanguages] objectAtIndex:0] containsString:@"ar"];
+        self.reverseContentLayout = [[[NSLocale preferredLanguages] objectAtIndex:0] hasPrefix:@"ar"];
     }
     
     _doneTextButton = [UIButton buttonWithType:UIButtonTypeSystem];


### PR DESCRIPTION
Hi Tim

Since the TOCropViewController is support iOS 7+, then it shouldn’t use -[NSString containsString:] in TOCropToolbar.m because the method is introduced for iOS 8+. So it crashed me on iOS 7 for sure. I replaced the method with -[NSString hasPrefix:].