### PR TITLE
Quick Fix #61

### DIFF
--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -314,9 +314,13 @@
     BOOL verticalCropBox = self.cropView.cropBoxAspectRatioIsPortrait;
     
     //Prepare the localized options
-    NSString *cancelButtonTitle = NSLocalizedStringFromTableInBundle(@"Cancel", @"TOCropViewControllerLocalizable", [NSBundle bundleForClass:[self class]], nil);
-    NSString *originalButtonTitle = NSLocalizedStringFromTableInBundle(@"Original", @"TOCropViewControllerLocalizable", [NSBundle bundleForClass:[self class]], nil);
-    NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", [NSBundle bundleForClass:[self class]], nil);
+    NSBundle* classBundle = [NSBundle bundleForClass:[self class]];
+    NSURL* resourceBundleURL = [classBundle URLForResource:@"TOCropViewControllerBundle" withExtension:@"bundle"];
+    NSBundle* resourceBundle = [[NSBundle alloc] initWithURL:resourceBundleURL];
+    
+    NSString *cancelButtonTitle = NSLocalizedStringFromTableInBundle(@"Cancel", @"TOCropViewControllerLocalizable", resourceBundle, nil);
+    NSString *originalButtonTitle = NSLocalizedStringFromTableInBundle(@"Original", @"TOCropViewControllerLocalizable", resourceBundle, nil);
+    NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
     NSMutableArray *items = [NSMutableArray array];

--- a/TOCropViewController/Views/TOCropToolbar.m
+++ b/TOCropViewController/Views/TOCropToolbar.m
@@ -75,10 +75,14 @@
         self.reverseContentLayout = [[[NSLocale preferredLanguages] objectAtIndex:0] hasPrefix:@"ar"];
     }
     
+    NSBundle* classBundle = [NSBundle bundleForClass:[self class]];
+    NSURL* resourceBundleURL = [classBundle URLForResource:@"TOCropViewControllerBundle" withExtension:@"bundle"];
+    NSBundle* resourceBundle = [[NSBundle alloc] initWithURL:resourceBundleURL];
+    
     _doneTextButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [_doneTextButton setTitle:NSLocalizedStringFromTableInBundle(@"Done",
                                                                  @"TOCropViewControllerLocalizable",
-                                                                 [NSBundle bundleForClass:[self class]],
+                                                                 resourceBundle,
                                                                  nil)
                      forState:UIControlStateNormal];
     [_doneTextButton setTitleColor:[UIColor colorWithRed:1.0f green:0.8f blue:0.0f alpha:1.0f] forState:UIControlStateNormal];
@@ -95,7 +99,7 @@
     _cancelTextButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [_cancelTextButton setTitle:NSLocalizedStringFromTableInBundle(@"Cancel",
                                                                    @"TOCropViewControllerLocalizable",
-                                                                   [NSBundle bundleForClass:[self class]],
+                                                                   resourceBundle,
                                                                    nil)
                        forState:UIControlStateNormal];
     [_cancelTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f]];


### PR DESCRIPTION
When using the library using CocoaPods, it does not display localized strings and @Sander-Kornev added issue #61 with the same problem. The original code tries to find the localized strings from `[NSBundle bundleForClass:[self class]]` but it seems the library cannot find the localized strings directly from that bundle. I guess it has something to do with pod spec but I have no idea about how to write podspec, so I made a quick fix to the problem, which searches the resource bundle containing the localized strings first, retrieving them from the bundle. Since this is my first time pulling a request, sorry in advance for a possible mistake :)