### PR TITLE
add ability to set initialCroppedImageFrame for TOCropView

### DIFF
--- a/TOCropViewController/Views/TOCropView.h
+++ b/TOCropViewController/Views/TOCropView.h
@@ -101,7 +101,12 @@
 @property (nonatomic, assign) BOOL croppingViewsHidden;
 
 /**
- In relation to the coordinate space of the image, the frame that the crop view is focussing on
+ In relation to the coordinate space of the image, initial value of the frame that the crop view is focusing on
+ */
+@property (nonatomic, assign) CGRect initialCroppedImageFrame; /* This is the initial croppedImageFrame, if not provided it's assumed to be the whole image */
+
+/**
+ In relation to the coordinate space of the image, the frame that the crop view is focusing on
  */
 @property (nonatomic, readonly) CGRect croppedImageFrame;
 


### PR DESCRIPTION
Hey, 

I've added support for preselecting a croppedImageFrame in TOCropView.

### The use case 
The user selects some cropping frame and closes the image crop view controller. Later he wants to go back to the same photo and see his previous selection, instead of the whole image selected.

### Implementation details:

- The main changes are in `layoutInitialImage` method, where I first select the whole image (as in the original implementation), then centre it to complete the layout and then adjust `cropBoxFrame` to match the provided `initialCroppedImageFrame` (as if the user was manipulating the CropOverlayView). I'm aware that I'm probably calling `moveCroppedContentToCenterAnimated` too many times in this method (twice in fact), and I could maybe do all the calculations for scrollView/cropBox manually, but this approach seemed quite natural. Please let me know if you have any better idea on how to approach it.

- I also modified the methods related to resetting layout to default as it needs to take the initial cropped image frame into account, so it doesn't reset to full selection.

Even if you don't decide to merge this pull request I'd be grateful for any comments, as I might have missed something in your implementation that makes my solution to complicated or buggy.

Thanks
Rafal