### PR TITLE
init rotate angle

### DIFF
--- a/TOCropViewController/Views/TOCropView.h
+++ b/TOCropViewController/Views/TOCropView.h
@@ -106,6 +106,11 @@
 @property (nonatomic, assign) CGRect initialCroppedImageFrame; /* This is the initial croppedImageFrame, if not provided it's assumed to be the whole image */
 
 /**
+ The initial rotation angle of the crop view
+ */
+@property (nonatomic, assign) NSInteger initialRotatedAngle; /* This is the initial rotatedAngle such as 90, 180, 270, 360 (also negative). */
+
+/**
  In relation to the coordinate space of the image, the frame that the crop view is focusing on
  */
 @property (nonatomic, readonly) CGRect croppedImageFrame;


### PR DESCRIPTION
I saw [the pull request](https://github.com/TimOliver/TOCropViewController/pull/83).

But it does not support rotation.

I want to init both rotate and crop. So I add init rotate angle. It's simple.

I also added to `layoutInitialImage` method. Just use your method `rotateImageNinetyDegreesAnimated`

It only supports 90, 180, 270 (also negative) not such as 92 degree.

Thanks.