### PR TITLE
Fixed localized string for german language

### DIFF
--- a/TOCropViewController/de.lproj/TOCropViewControllerLocalizable.strings
+++ b/TOCropViewController/de.lproj/TOCropViewControllerLocalizable.strings
@@ -1,4 +1,4 @@
-"Done" = "Done";
+"Done" = "Fertig";
 "Cancel" = "Abbrechen";
 "Reset" = "Zurücksetzen";
 "Original" = "Original";


### PR DESCRIPTION
In german "Done" should be "Fertig".