### PR TITLE
Use `self.scale` rather than `[UIScreen mainScreen].scale` to not get…

### DIFF
--- a/TOCropViewController/Models/UIImage+CropRotate.m
+++ b/TOCropViewController/Models/UIImage+CropRotate.m
@@ -66,7 +66,7 @@
     }
     UIGraphicsEndImageContext();
     
-    return [UIImage imageWithCGImage:croppedImage.CGImage scale:[UIScreen mainScreen].scale orientation:UIImageOrientationUp];
+    return [UIImage imageWithCGImage:croppedImage.CGImage scale:self.scale orientation:UIImageOrientationUp];
 }
 
 


### PR DESCRIPTION
… a downscaled image (seems to only appear when the image has been rotated before).

I'm not quite sure why this only happens when the image has been rotated before. Either way, I think `[UIScreen mainScreen].scale` is wrong there. What do you think?