### PR TITLE
Fixed aliasing issue

### DIFF
--- a/TOCropViewController/Views/TOCropView.m
+++ b/TOCropViewController/Views/TOCropView.m
@@ -194,7 +194,8 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     
     //Background Image View
     self.backgroundImageView = [[UIImageView alloc] initWithImage:self.image];
-
+    self.backgroundImageView.layer.minificationFilter = kCAFilterTrilinear;
+    
     //Background container view
     self.backgroundContainerView = [[UIView alloc] initWithFrame:self.backgroundImageView.frame];
     [self.backgroundContainerView addSubview:self.backgroundImageView];
@@ -232,6 +233,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     [self addSubview:self.foregroundContainerView];
     
     self.foregroundImageView = [[UIImageView alloc] initWithImage:self.image];
+    self.foregroundImageView.layer.minificationFilter = kCAFilterTrilinear;
     [self.foregroundContainerView addSubview:self.foregroundImageView];
     
     // The following setup isn't needed during circular cropping


### PR DESCRIPTION
I found some aliasing issue when importing some high resolution photo. Seems like minificationFilter's default option isn't doing well in anti-aliasing, I change it to kCAFilterTrilinear

Below is the result:

<img width="1120" alt="123" src="https://cloud.githubusercontent.com/assets/6956493/20201834/f5e95324-a7f5-11e6-827e-44fe3fe57ff0.png">

