### PR TITLE
Add title label to the top of the view controller when title is set on the view controller

### DIFF
--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -155,6 +155,11 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nonatomic, assign) CGSize customAspectRatio;
 
 /**
+ Title label which can used to show instruction on the top of the crop view controller
+ */
+@property (nonnull, nonatomic, strong, readonly) UILabel *titleLabel;
+
+/**
  If true, while it can still be resized, the crop box will be locked to its current aspect ratio.
  
  If this is set to YES, and `resetAspectRatioEnabled` is set to NO, then the aspect ratio

--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nonatomic, assign) CGSize customAspectRatio;
 
 /**
- Title label which can used to show instruction on the top of the crop view controller
+ Title label which can be used to show instruction on the top of the crop view controller
  */
 @property (nonnull, nonatomic, strong, readonly) UILabel *titleLabel;
 

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -119,7 +119,10 @@ CGFloat titleLabelHeight;
 	// only place title label into the view if the title is defined
 	if(self.title.length > 0){
 		titleLabelHeight = 30.0f;
-		self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, titleLabelHeight)];
+		CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+		
+		// add status bar height to origin y so that it will not obstruct status bar
+		self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, statusBarHeight, self.view.frame.size.width, titleLabelHeight)];
 		self.titleLabel.font = [UIFont systemFontOfSize:14.0];
 		self.titleLabel.backgroundColor = [UIColor clearColor];
 		self.titleLabel.textColor = [UIColor whiteColor];
@@ -129,6 +132,10 @@ CGFloat titleLabelHeight;
 		self.titleLabel.textAlignment = NSTextAlignmentCenter;
 		self.titleLabel.text = self.title;
 		[self.view insertSubview:self.titleLabel aboveSubview:self.cropView];
+		
+		_cropView.cropRegionInsets = UIEdgeInsetsMake(titleLabelHeight, 0, 0, 0);
+	} else {
+		_cropView.cropRegionInsets = UIEdgeInsetsMake(0, 0, 0, 0);
 	}
 	
 	
@@ -287,25 +294,28 @@ CGFloat titleLabelHeight;
     else {
         bounds = self.parentViewController.view.bounds;
     }
-    
+	
+	
     CGRect frame = CGRectZero;
     if (!verticalLayout) {
         frame.origin.x = 44.0f;
-        frame.origin.y = 0.0f + titleLabelHeight;
+		frame.origin.y = 0.0f;
+		
         frame.size.width = CGRectGetWidth(bounds) - 44.0f;
-        frame.size.height = CGRectGetHeight(bounds) - titleLabelHeight;
+		frame.size.height = CGRectGetHeight(bounds);
+		
     }
     else {
         frame.origin.x = 0.0f;
         
         if (_toolbarPosition == TOCropViewControllerToolbarPositionBottom) {
-            frame.origin.y = 0.0f + titleLabelHeight;
+			frame.origin.y = 0.0f;
         } else {
-            frame.origin.y = 44.0f + titleLabelHeight;
+			frame.origin.y = 44.0f;
         }
 
         frame.size.width = CGRectGetWidth(bounds);
-        frame.size.height = CGRectGetHeight(bounds) - 44.0f - titleLabelHeight;
+		frame.size.height = CGRectGetHeight(bounds) - 44.0f;
     }
     
     return frame;

--- a/TOCropViewControllerExample/ViewController.m
+++ b/TOCropViewControllerExample/ViewController.m
@@ -39,6 +39,7 @@
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingImage:(UIImage *)image editingInfo:(NSDictionary *)editingInfo
 {
     TOCropViewController *cropController = [[TOCropViewController alloc] initWithCroppingStyle:self.croppingStyle image:image];
+	[cropController setTitle:@"Crop Image"];
     cropController.delegate = self;
     
     // -- Uncomment these if you want to test out restoring to a previous crop setting --


### PR DESCRIPTION
#163 

Add title label to the top of the view controller when title is set via setTitle: method from the view controller.

The title label can be accessed from **titleLabel** property.

eg : 
```
TOCropViewController *cropController = [[TOCropViewController alloc] initWithCroppingStyle:self.croppingStyle image:image];
[cropController setTitle:@"Crop Image"];
cropController.delegate = self;
[self presentViewController:cropController animated:YES completion:nil];
```