### PR TITLE
Import the necessary headers in the bridging header.

### DIFF
--- a/TOCropViewController/TOCropViewController-Bridging-Header.h
+++ b/TOCropViewController/TOCropViewController-Bridging-Header.h
@@ -24,3 +24,8 @@
 #import "TOCropView.h"
 #import "TOCropToolbar.h"
 #import "TOCropOverlayView.h"
+#import "TOActivityCroppedImageProvider.h"
+#import "TOCroppedImageAttributes.h"
+#import "TOCropScrollView.h"
+#import "TOCropViewControllerTransitioning.h"
+#import "UIImage+CropRotate.h"


### PR DESCRIPTION
Fixes these build errors when using Carthage:
```
2017-08-18T15:29:54.499Z - ce:     ✗ <module-includes>:1:1: error: umbrella header for module 'TOCropViewController' does not include header 'TOActivityCroppedImageProvider.h'

2017-08-18T15:29:54.501Z - ci:     » #import "Headers/TOCropViewController.h"

2017-08-18T15:29:54.503Z - ci:     » ^

2017-08-18T15:29:54.506Z - ce:     ✗ <module-includes>:1:1: error: umbrella header for module 'TOCropViewController' does not include header 'TOCroppedImageAttributes.h'

2017-08-18T15:29:54.508Z - ci:     » #import "Headers/TOCropViewController.h"

2017-08-18T15:29:54.510Z - ci:     » ^

2017-08-18T15:29:54.513Z - ce:     ✗ <module-includes>:1:1: error: umbrella header for module 'TOCropViewController' does not include header 'TOCropScrollView.h'

2017-08-18T15:29:54.515Z - ci:     » #import "Headers/TOCropViewController.h"

2017-08-18T15:29:54.517Z - ci:     » ^

2017-08-18T15:29:54.563Z - ce:     ✗ <module-includes>:1:1: error: umbrella header for module 'TOCropViewController' does not include header 'TOCropViewControllerTransitioning.h'

2017-08-18T15:29:54.565Z - ci:     » #import "Headers/TOCropViewController.h"

2017-08-18T15:29:54.568Z - ci:     » ^

2017-08-18T15:29:54.570Z - ce:     ✗ <module-includes>:1:1: error: umbrella header for module 'TOCropViewController' does not include header 'UIImage+CropRotate.h'

2017-08-18T15:29:54.572Z - ci:     » #import "Headers/TOCropViewController.h"

2017-08-18T15:29:54.574Z - ci:     » ^

2017-08-18T15:29:54.606Z - ce:     ** ARCHIVE FAILED **

2017-08-18T15:29:54.608Z - ce:     The following build commands failed:

2017-08-18T15:29:54.610Z - ce:     	CompileSwift normal arm64

2017-08-18T15:29:54.612Z - ce:     	CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler

2017-08-18T15:29:54.614Z - ce:     (2 failures)
```