### PR TITLE
Adding a new property on TOCropView aspectRatioAllowDimensionSwap

### DIFF
--- a/TOCropViewController/TOCropViewController.h
+++ b/TOCropViewController/TOCropViewController.h
@@ -162,6 +162,13 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nullable, nonatomic, readonly) UILabel *titleLabel;
 
 /**
+ If true, a custom aspect ratio is set, and the aspectRatioLockEnabled is set to YES, the crop box will swap it's dimensions depending on portrait or landscape sized images.
+ 
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL aspectRatioLockAllowDimensionSwap;
+
+/**
  If true, while it can still be resized, the crop box will be locked to its current aspect ratio.
  
  If this is set to YES, and `resetAspectRatioEnabled` is set to NO, then the aspect ratio

--- a/TOCropViewController/TOCropViewController.m
+++ b/TOCropViewController/TOCropViewController.m
@@ -594,10 +594,17 @@ CGFloat titleLabelHeight;
             break;
     }
     
+    /*
+     * If the aspectratio lock is not enabled, allow a swap
+     *
+     * If the aspect ratio lock is on, allow a aspect ratio swap
+     * only if the allowDimensionSwap option is specified.
+    */
+    BOOL aspectRatioCanSwapDimensions = !self.aspectRatioLockEnabled || (self.aspectRatioLockEnabled && self.aspectRatioLockAllowDimensionSwap);
+    
     //If the image is a portrait shape, flip the aspect ratio to match
-    if (aspectRatioPreset != TOCropViewControllerAspectRatioPresetCustom &&
-        self.cropView.cropBoxAspectRatioIsPortrait &&
-        !self.aspectRatioLockEnabled)
+    if (self.cropView.cropBoxAspectRatioIsPortrait &&
+        aspectRatioCanSwapDimensions)
     {
         CGFloat width = aspectRatio.width;
         aspectRatio.width = aspectRatio.height;
@@ -1010,6 +1017,16 @@ CGFloat titleLabelHeight;
 - (BOOL)aspectRatioLockEnabled
 {
     return self.cropView.aspectRatioLockEnabled;
+}
+
+-(void)setAspectRatioLockAllowDimensionSwap:(BOOL)aspectRatioLockAllowDimensionSwap
+{
+    self.cropView.aspectRatioAllowDimensionSwap = aspectRatioLockAllowDimensionSwap;
+}
+
+-(BOOL)aspectRatioLockAllowDimensionSwap
+{
+    return self.cropView.aspectRatioAllowDimensionSwap;
 }
 
 - (void)setRotateButtonsHidden:(BOOL)rotateButtonsHidden

--- a/TOCropViewController/Views/TOCropView.h
+++ b/TOCropViewController/Views/TOCropView.h
@@ -107,6 +107,12 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
 @property (nonatomic, assign) BOOL aspectRatioLockEnabled;
 
 /**
+ When the aspectRatioLockEnabled is true and this is true, the photo can adjust for different
+ orientations by swapping the aspect ratio as appropriate
+ */
+@property (nonatomic, assign) BOOL aspectRatioAllowDimensionSwap;
+
+/**
  When the user taps 'reset', whether the aspect ratio will also be reset as well
  Default is YES
  */

--- a/TOCropViewController/Views/TOCropView.m
+++ b/TOCropViewController/Views/TOCropView.m
@@ -172,6 +172,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     self.cropBoxResizeEnabled = !circularMode;
     self.aspectRatio = circularMode ? (CGSize){1.0f, 1.0f} : CGSizeZero;
     self.resetAspectRatioEnabled = !circularMode;
+    self.aspectRatioAllowDimensionSwap = NO;
     self.restoreImageCropFrame = CGRectZero;
     self.restoreAngle = 0;
     


### PR DESCRIPTION
Which is exposed via a get/set on TOCropViewController as aspectRatioLockAllowDimensionSwap. This property is used when combined with aspectRatioLockEnabled to allow for TOCropViewController to swap the croppers dimensions for custom aspect ratios, like the preset ones. By default this is set to no to preserve existing behavior.

---------------------------------

Hey Tim!

Love your crop view controller, and added this functionality for my own personal app which is getting a new release soon. 

I needed to be able to allow swapping of the aspect ratio frame on the cropper when using a custom aspect ratio for toggling between portrait and landscape photos. This code has met my needs and I've attempted to minimize code changes. 

I totally get it if this doesn't get merged down, but thought I should contribute it back to be a good member of the community. 