### PR TITLE
Fixing Cocoapods - Release 2.1.1

### DIFF
--- a/TOCropViewController.podspec
+++ b/TOCropViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'TOCropViewController'
-  s.version  = '2.1.0'
+  s.version  = '2.1.1'
   s.license  =  { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A view controller that allows users to crop UIImage objects.'
   s.homepage = 'https://github.com/TimOliver/TOCropViewController'


### PR DESCRIPTION
This pull request is just to fix Cocoapods. Now there is no option to build the app with this dependency using the newest version - 2.1.0 is corrupted because of missing semicolons.