### PR TITLE
Fix frame if outside of image

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -1026,7 +1026,17 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     
     frame.size.height = ceilf(cropBoxFrame.size.height * (imageSize.height / contentSize.height));
     frame.size.height = MIN(imageSize.height, frame.size.height);
-    
+
+    // if frame goes beyond boundaries of the image, we move it back
+    // so it is within the boundaries.
+    if (frame.origin.x + frame.size.width > imageSize.width) {
+        frame.origin.x = imageSize.width - frame.size.width;
+    }
+
+    if (frame.origin.y + frame.size.height > imageSize.height) {
+        frame.origin.y = imageSize.height - frame.size.height;
+    }
+
     return frame;
 }
 


### PR DESCRIPTION
If `frame` is outside of image, `frame` gets adjusted so it is within boundaries of the image.

You can have `frame` outside of the image by dragging the crop rect outside the image and quickly tapping done.

I've tested the change. 

Please let me know if you want me to do anything else.
