### PR TITLE
Added minimal aspect ratio lock parameter

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -105,7 +105,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 /**
  The minimum croping aspect ratio. If set, user is prevented from setting cropping rectangle to lower aspect ratio than defined by the parameter.
  */
-@property (nonatomic, assign) CGFloat minimalCroppingAspectRatio;
+@property (nonatomic, assign) CGFloat minimumAspectRatio;
 
 /**
  The view controller's delegate that will receive the resulting
@@ -312,14 +312,6 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
  @param image The image that will be cropped
  */
 - (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image NS_SWIFT_NAME(init(croppingStyle:image:));
-
-/**
- Creates a new instance of a crop view controller with the supplied image and cropping style with minimal width/height ratio
-@param style The cropping style that will be used with this view controller (eg, rectangular, or circular)
-@param image The image that will be cropped
-@param minimumCropRatio Minimal width/height or height/width ratio used for resizing image. When minimal ratio is reached, cropping rectangle stops changing.
-*/
-- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimumCropRatio:(CGFloat)minimumCropRatio NS_SWIFT_NAME(init(croppingStyle:image:minimumCropRatio:));
 
 /**
  Resets object of TOCropViewController class as if user pressed reset button in the bottom bar themself

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -103,6 +103,11 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nonnull, nonatomic, readonly) UIImage *image;
 
 /**
+ The minimum croping aspect ratio. If set, user is prevented from setting cropping rectangle to lower aspect ratio than defined by the parameter.
+ */
+@property (nonatomic, assign) CGFloat minimalCroppingAspectRatio;
+
+/**
  The view controller's delegate that will receive the resulting
  cropped image, as well as crop information.
  */
@@ -307,6 +312,14 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
  @param image The image that will be cropped
  */
 - (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image NS_SWIFT_NAME(init(croppingStyle:image:));
+
+/**
+ Creates a new instance of a crop view controller with the supplied image and cropping style with minimal width/height ratio
+@param style The cropping style that will be used with this view controller (eg, rectangular, or circular)
+@param image The image that will be cropped
+@param minimumCropRatio Minimal width/height or height/width ratio used for resizing image. When minimal ratio is reached, cropping rectangle stops changing.
+*/
+- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimumCropRatio:(CGFloat)minimumCropRatio NS_SWIFT_NAME(init(croppingStyle:image:minimumCropRatio:));
 
 /**
  Resets object of TOCropViewController class as if user pressed reset button in the bottom bar themself

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -102,17 +102,6 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self;
 }
 
-- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimumCropRatio:(CGFloat)minimumCropRatio NS_SWIFT_NAME(init(croppingStyle:image:minimumCropRatio:)){
-    NSParameterAssert(image);
-    
-    self = [self initWithCroppingStyle:style image:image];
-    if (self) {
-        self.minimalCroppingAspectRatio = minimumCropRatio;
-    }
-    
-    return self;
-}
-
 - (instancetype)initWithImage:(UIImage *)image
 {
     return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];
@@ -1084,7 +1073,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     // Lazily create the crop view in case we try and access it before presentation, but
     // don't add it until our parent view controller view has loaded at the right time
     if (!_cropView) {
-        _cropView = [[TOCropView alloc] initWithCroppingStyle:self.croppingStyle image:self.image minimalAspectRatio:_minimalCroppingAspectRatio];
+        _cropView = [[TOCropView alloc] initWithCroppingStyle:self.croppingStyle image:self.image];
         _cropView.delegate = self;
         _cropView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         [self.view addSubview:_cropView];
@@ -1277,6 +1266,16 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     }
 
     return insets;
+}
+
+- (void)setMinimumAspectRatio:(CGFloat)minimumAspectRatio
+{
+    self.cropView.minimumAspectRatio = minimumAspectRatio;
+}
+
+- (CGFloat)minimumAspectRatio
+{
+    return self.cropView.minimumAspectRatio;
 }
 
 @end

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -102,6 +102,17 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self;
 }
 
+- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimumCropRatio:(CGFloat)minimumCropRatio NS_SWIFT_NAME(init(croppingStyle:image:minimumCropRatio:)){
+    NSParameterAssert(image);
+    
+    self = [self initWithCroppingStyle:style image:image];
+    if (self) {
+        self.minimalCroppingAspectRatio = minimumCropRatio;
+    }
+    
+    return self;
+}
+
 - (instancetype)initWithImage:(UIImage *)image
 {
     return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];
@@ -1073,7 +1084,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     // Lazily create the crop view in case we try and access it before presentation, but
     // don't add it until our parent view controller view has loaded at the right time
     if (!_cropView) {
-        _cropView = [[TOCropView alloc] initWithCroppingStyle:self.croppingStyle image:self.image];
+        _cropView = [[TOCropView alloc] initWithCroppingStyle:self.croppingStyle image:self.image minimalAspectRatio:_minimalCroppingAspectRatio];
         _cropView.delegate = self;
         _cropView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         [self.view addSubview:_cropView];

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -141,7 +141,7 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
 /**
 The minimum croping aspect ratio. If set, user is prevented from setting cropping rectangle to lower aspect ratio than defined by the parameter.
 */
-@property (nonatomic, assign) CGFloat minimalCroppingAspectRatio;
+@property (nonatomic, assign) CGFloat minimumAspectRatio;
 
 /**
  Create a default instance of the crop view with the supplied image
@@ -152,11 +152,6 @@ The minimum croping aspect ratio. If set, user is prevented from setting croppin
  Create a new instance of the crop view with the specified image and cropping
  */
 - (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image;
-
-/**
- Create a new instance of the crop view with the specified image, cropping style and minimal aspect ratio
- */
-- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimalAspectRatio:(CGFloat)minimalAspectRatio;
 
 /**
  Performs the initial set up, including laying out the image and applying any restore properties.

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -139,6 +139,11 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
 @property (nonatomic, assign) BOOL gridOverlayHidden;
 
 /**
+The minimum croping aspect ratio. If set, user is prevented from setting cropping rectangle to lower aspect ratio than defined by the parameter.
+*/
+@property (nonatomic, assign) CGFloat minimalCroppingAspectRatio;
+
+/**
  Create a default instance of the crop view with the supplied image
  */
 - (nonnull instancetype)initWithImage:(nonnull UIImage *)image;
@@ -147,6 +152,11 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
  Create a new instance of the crop view with the specified image and cropping
  */
 - (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image;
+
+/**
+ Create a new instance of the crop view with the specified image, cropping style and minimal aspect ratio
+ */
+- (nonnull instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(nonnull UIImage *)image minimalAspectRatio:(CGFloat)minimalAspectRatio;
 
 /**
  Performs the initial set up, including laying out the image and applying any restore properties.

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -129,15 +129,6 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     return self;
 }
 
-- (instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(UIImage *)image minimalAspectRatio:(CGFloat)minimalAspectRatio
-{
-    if (self = [self initWithCroppingStyle:style image:image]) {
-        self.minimalCroppingAspectRatio = minimalAspectRatio;
-    }
-    
-    return self;
-}
-
 - (void)setup
 {
     __weak typeof(self) weakSelf = self;
@@ -449,7 +440,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
             }
             CGFloat newWidth = originFrame.size.width - xDelta;
             CGFloat newHeight = originFrame.size.height;
-            if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+            if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                 frame.origin.x   = originFrame.origin.x + xDelta;
                 frame.size.width = originFrame.size.width - xDelta;
             }
@@ -469,7 +460,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
             else {
                 CGFloat newWidth = originFrame.size.width + xDelta;
                 CGFloat newHeight = originFrame.size.height;
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.size.width = originFrame.size.width + xDelta;
                 }
             }
@@ -488,7 +479,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width;
                 CGFloat newHeight = originFrame.size.height + yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.size.height = originFrame.size.height + yDelta;
                 }
             }
@@ -507,7 +498,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width;
                 CGFloat newHeight = originFrame.size.height - yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.origin.y    = originFrame.origin.y + yDelta;
                     frame.size.height = originFrame.size.height - yDelta;
                 }
@@ -539,7 +530,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width - xDelta;
                 CGFloat newHeight = originFrame.size.height - yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.origin.x   = originFrame.origin.x + xDelta;
                     frame.size.width = originFrame.size.width - xDelta;
                     frame.origin.y   = originFrame.origin.y + yDelta;
@@ -573,7 +564,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width + xDelta;
                 CGFloat newHeight = originFrame.size.height - yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.size.width  = originFrame.size.width + xDelta;
                     frame.origin.y    = originFrame.origin.y + yDelta;
                     frame.size.height = originFrame.size.height - yDelta;
@@ -602,7 +593,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width - xDelta;
                 CGFloat newHeight = originFrame.size.height + yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.size.height = originFrame.size.height + yDelta;
                     frame.origin.x    = originFrame.origin.x + xDelta;
                     frame.size.width  = originFrame.size.width - xDelta;
@@ -631,7 +622,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 CGFloat newWidth = originFrame.size.width + xDelta;
                 CGFloat newHeight = originFrame.size.height + yDelta;
                 
-                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimumAspectRatio) {
                     frame.size.height = originFrame.size.height + yDelta;
                     frame.size.width = originFrame.size.width + xDelta;
                 }

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -113,6 +113,11 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
 
 @implementation TOCropView
 
+- (instancetype)initWithImage:(UIImage *)image
+{
+    return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];
+}
+
 - (instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(UIImage *)image
 {
     if (self = [super init]) {
@@ -124,9 +129,13 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     return self;
 }
 
-- (instancetype)initWithImage:(UIImage *)image
+- (instancetype)initWithCroppingStyle:(TOCropViewCroppingStyle)style image:(UIImage *)image minimalAspectRatio:(CGFloat)minimalAspectRatio
 {
-    return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];
+    if (self = [self initWithCroppingStyle:style image:image]) {
+        self.minimalCroppingAspectRatio = minimalAspectRatio;
+    }
+    
+    return self;
 }
 
 - (void)setup
@@ -438,9 +447,12 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 frame.size.height = frame.size.width / aspectRatio;
                 frame.origin.y = scaleOrigin.y - (frame.size.height * 0.5f);
             }
-            
-            frame.origin.x   = originFrame.origin.x + xDelta;
-            frame.size.width = originFrame.size.width - xDelta;
+            CGFloat newWidth = originFrame.size.width - xDelta;
+            CGFloat newHeight = originFrame.size.height;
+            if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                frame.origin.x   = originFrame.origin.x + xDelta;
+                frame.size.width = originFrame.size.width - xDelta;
+            }
             
             clampMinFromLeft = YES;
             
@@ -455,7 +467,11 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 frame.size.width = MIN(frame.size.width, contentFrame.size.height * aspectRatio);
             }
             else {
-                frame.size.width = originFrame.size.width + xDelta;
+                CGFloat newWidth = originFrame.size.width + xDelta;
+                CGFloat newHeight = originFrame.size.height;
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.size.width = originFrame.size.width + xDelta;
+                }
             }
             
             break;
@@ -469,7 +485,12 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 frame.size.height = MIN(frame.size.height, contentFrame.size.width / aspectRatio);
             }
             else {
-                frame.size.height = originFrame.size.height + yDelta;
+                CGFloat newWidth = originFrame.size.width;
+                CGFloat newHeight = originFrame.size.height + yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.size.height = originFrame.size.height + yDelta;
+                }
             }
             break;
         case TOCropViewOverlayEdgeTop:
@@ -483,8 +504,13 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 frame.size.height = originFrame.size.height - yDelta;
             }
             else {
-                frame.origin.y    = originFrame.origin.y + yDelta;
-                frame.size.height = originFrame.size.height - yDelta;
+                CGFloat newWidth = originFrame.size.width;
+                CGFloat newHeight = originFrame.size.height - yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.origin.y    = originFrame.origin.y + yDelta;
+                    frame.size.height = originFrame.size.height - yDelta;
+                }
             }
             
             clampMinFromTop = YES;
@@ -510,10 +536,15 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 aspectHorizontal = YES;
             }
             else {
-                frame.origin.x   = originFrame.origin.x + xDelta;
-                frame.size.width = originFrame.size.width - xDelta;
-                frame.origin.y   = originFrame.origin.y + yDelta;
-                frame.size.height = originFrame.size.height - yDelta;
+                CGFloat newWidth = originFrame.size.width - xDelta;
+                CGFloat newHeight = originFrame.size.height - yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.origin.x   = originFrame.origin.x + xDelta;
+                    frame.size.width = originFrame.size.width - xDelta;
+                    frame.origin.y   = originFrame.origin.y + yDelta;
+                    frame.size.height = originFrame.size.height - yDelta;
+                }
             }
             
             clampMinFromTop = YES;
@@ -539,9 +570,14 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 aspectHorizontal = YES;
             }
             else {
-                frame.size.width  = originFrame.size.width + xDelta;
-                frame.origin.y    = originFrame.origin.y + yDelta;
-                frame.size.height = originFrame.size.height - yDelta;
+                CGFloat newWidth = originFrame.size.width + xDelta;
+                CGFloat newHeight = originFrame.size.height - yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.size.width  = originFrame.size.width + xDelta;
+                    frame.origin.y    = originFrame.origin.y + yDelta;
+                    frame.size.height = originFrame.size.height - yDelta;
+                }
             }
             
             clampMinFromTop = YES;
@@ -563,9 +599,14 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 aspectHorizontal = YES;
             }
             else {
-                frame.size.height = originFrame.size.height + yDelta;
-                frame.origin.x    = originFrame.origin.x + xDelta;
-                frame.size.width  = originFrame.size.width - xDelta;
+                CGFloat newWidth = originFrame.size.width - xDelta;
+                CGFloat newHeight = originFrame.size.height + yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.size.height = originFrame.size.height + yDelta;
+                    frame.origin.x    = originFrame.origin.x + xDelta;
+                    frame.size.width  = originFrame.size.width - xDelta;
+                }
             }
             
             clampMinFromLeft = YES;
@@ -587,8 +628,13 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
                 aspectHorizontal = YES;
             }
             else {
-                frame.size.height = originFrame.size.height + yDelta;
-                frame.size.width = originFrame.size.width + xDelta;
+                CGFloat newWidth = originFrame.size.width + xDelta;
+                CGFloat newHeight = originFrame.size.height + yDelta;
+                
+                if (MIN(newHeight, newWidth) / MAX(newHeight, newWidth) >= (double)_minimalCroppingAspectRatio) {
+                    frame.size.height = originFrame.size.height + yDelta;
+                    frame.size.width = originFrame.size.width + xDelta;
+                }
             }
             break;
         case TOCropViewOverlayEdgeNone: break;


### PR DESCRIPTION
Hi @TimOliver ,

It is very useful to have the option to prevent users to make images with too small width or height. I added the parameter which defines how much times height can be bigger than the width and vice versa. For example, if minimalAspect ratio parameter is set to 0.4, that would mean that the smallest width can be 0.4 * height, and smallest height can be 0.4 * width. A user can still change cropping rectangle with dragging gesture, but when the minimal aspect ratio is reached rectangle locks dimension unless user drags it to a proper size.

We really appreciate your work on this library, we use it our app and we would be very happy to give us some feedback on this pull request and what should I do to have this additional feature into the library. 

Best regards,

Milan