### PR TITLE
TitleLabel text can be set now

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -169,6 +169,12 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nullable, nonatomic, readonly) UILabel *titleLabel;
 
 /**
+ Title for the 'Title' label.
+ Setting this will override the Default which is nothing.
+ */
+@property (nullable, nonatomic, copy) NSString *titleLabelText;
+
+/**
  Title for the 'Done' button.
  Setting this will override the Default which is a localized string for "Done".
  */

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -169,8 +169,8 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nullable, nonatomic, readonly) UILabel *titleLabel;
 
 /**
- Title for the 'Title' label.
- Setting this will override the Default which is nothing.
+ Text for 'Title' label.
+ The default value is empty.
  */
 @property (nullable, nonatomic, copy) NSString *titleLabelText;
 

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1057,8 +1057,13 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     }
 
     self.titleLabel.text = self.title;
+    self.titleLabel.numberOfLines = 0;
     [self.titleLabel sizeToFit];
     self.titleLabel.frame = [self frameForTitleLabelWithSize:self.titleLabel.frame.size verticalLayout:self.verticalLayout];
+}
+
+- (void)setTitleLabelText:(NSString *)title {
+    [self setTitle: title];
 }
 
 - (void)setDoneButtonTitle:(NSString *)title {

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -325,6 +325,15 @@ public class CropViewController: UIViewController, TOCropViewControllerDelegate 
     }
     
     /**
+     Text for the 'Title' label.
+     Setting this will override the Default which is nothing.
+     */
+    public var titleLabelText: String! {
+        set { toCropViewController.titleLabelText = newValue }
+        get { return toCropViewController.titleLabelText }
+    }
+    
+    /**
      Title for the 'Done' button.
      Setting this will override the Default which is a localized string for "Done".
      */

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -325,9 +325,9 @@ public class CropViewController: UIViewController, TOCropViewControllerDelegate 
     }
     
     /**
-     Text for the 'Title' label.
-     Setting this will override the Default which is nothing.
-     */
+     Text for 'Title' label.
+     The default value is empty.
+    */
     public var titleLabelText: String! {
         set { toCropViewController.titleLabelText = newValue }
         get { return toCropViewController.titleLabelText }


### PR DESCRIPTION
Hi! Regarding issue #241, I've implemented a 'fix' for it. I tried to take 'setDoneButtonTitle' and 'setCancelButtonTitle' as an example of how to do it (since I'm not very familiar with Objective-C). Unfortunately I couldn't test on an iPad but I did test it on my iPhone 7.