### PR TITLE
Make dimension swap apply to rotating images in crop and some tweaks

### DIFF
--- a/CropViewController.podspec
+++ b/CropViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CropViewController'
-  s.version  = '2.3.6'
+  s.version  = '2.3.7'
   s.license  =  { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A Swift view controller that enables cropping and rotating of UIImage objects.'
   s.homepage = 'https://github.com/TimOliver/TOCropViewController'

--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
@@ -24,6 +24,6 @@
 
 @interface UIImage (CropRotate)
 
--(nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
+-(nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular;
 
 @end

--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
@@ -24,6 +24,8 @@
 
 @interface UIImage (CropRotate)
 
-- (nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular;
+-(nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular;
+
+- (nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular scale:(CGFloat)scale;
 
 @end

--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.h
@@ -24,8 +24,6 @@
 
 @interface UIImage (CropRotate)
 
--(nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular;
-
-- (nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular scale:(CGFloat)scale;
+-(nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
 
 @end

--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
@@ -31,11 +31,6 @@
             alphaInfo == kCGImageAlphaPremultipliedFirst || alphaInfo == kCGImageAlphaPremultipliedLast);
 }
 
--(UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
-{
-    return [self croppedImageWithFrame:frame angle:angle circularClip:circular scale:[UIScreen mainScreen].scale];
-}
-
 - (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular scale:(CGFloat)scale
 {
     UIImage *croppedImage = nil;

--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
@@ -31,7 +31,12 @@
             alphaInfo == kCGImageAlphaPremultipliedFirst || alphaInfo == kCGImageAlphaPremultipliedLast);
 }
 
-- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
+-(UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
+{
+    return [self croppedImageWithFrame:frame angle:angle circularClip:circular scale:[UIScreen mainScreen].scale];
+}
+
+- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular scale:(CGFloat)scale
 {
     UIImage *croppedImage = nil;
     UIGraphicsBeginImageContextWithOptions(frame.size, ![self hasAlpha] && !circular, self.scale);
@@ -66,7 +71,7 @@
     }
     UIGraphicsEndImageContext();
     
-    return [UIImage imageWithCGImage:croppedImage.CGImage scale:[UIScreen mainScreen].scale orientation:UIImageOrientationUp];
+    return [UIImage imageWithCGImage:croppedImage.CGImage scale:scale orientation:UIImageOrientationUp];
 }
 
 

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -181,7 +181,7 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {
 @property (nullable, nonatomic, copy) NSString *cancelButtonTitle;
 
 /**
- If true, a custom aspect ratio is set, and the aspectRatioLockEnabled is set to YES, the crop box will swap it's dimensions depending on portrait or landscape sized images.
+ If true, a custom aspect ratio is set, and the aspectRatioLockEnabled is set to YES, the crop box will swap it's dimensions depending on portrait or landscape sized images.  This value also controls whether the dimensions can swap when the image is rotated.
  
  Default is NO.
  */

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1118,6 +1118,11 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     }
 }
 
+- (void)setAspectRatioLockDimensionSwapEnabled:(BOOL)aspectRatioLockDimensionSwapEnabled
+{
+    self.cropView.aspectRatioLockDimensionSwapEnabled = aspectRatioLockDimensionSwapEnabled;
+}
+
 - (BOOL)aspectRatioLockEnabled
 {
     return self.cropView.aspectRatioLockEnabled;

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -108,6 +108,13 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
 @property (nonatomic, assign) BOOL aspectRatioLockEnabled;
 
 /**
+ If true, a custom aspect ratio is set, and the aspectRatioLockEnabled is set to YES, the crop box will swap it's dimensions depending on portrait or landscape sized images.  This value also controls whether the dimensions can swap when the image is rotated.
+ 
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL aspectRatioLockDimensionSwapEnabled;
+
+/**
  When the user taps 'reset', whether the aspect ratio will also be reset as well
  Default is YES
  */

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -1621,6 +1621,10 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
             } completion:^(BOOL complete) {
                 self.rotateAnimationInProgress = NO;
                 [snapshotView removeFromSuperview];
+                if (!self.aspectRatioLockDimensionSwapEnabled) {
+                    //This will animate the aspect ratio back to the desired locked ratio after the image is rotated.
+                    [self setAspectRatio:self.aspectRatio animated:animated];
+                }
             }];
         }];
     }

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -1621,7 +1621,14 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
             } completion:^(BOOL complete) {
                 self.rotateAnimationInProgress = NO;
                 [snapshotView removeFromSuperview];
-                if (!self.aspectRatioLockDimensionSwapEnabled) {
+                
+                // If the aspect ratio lock is not enabled, allow a swap
+                // If the aspect ratio lock is on, allow a aspect ratio swap
+                // only if the allowDimensionSwap option is specified.
+                BOOL aspectRatioCanSwapDimensions = !self.aspectRatioLockEnabled ||
+                (self.aspectRatioLockEnabled && self.aspectRatioLockDimensionSwapEnabled);
+                
+                if (!aspectRatioCanSwapDimensions) {
                     //This will animate the aspect ratio back to the desired locked ratio after the image is rotated.
                     [self setAspectRatio:self.aspectRatio animated:animated];
                 }

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -81,7 +81,6 @@
     TOCropViewController *cropController = [[TOCropViewController alloc] initWithCroppingStyle:self.croppingStyle image:self.image];
     cropController.delegate = self;
     CGRect viewFrame = [self.view convertRect:self.imageView.frame toView:self.navigationController.view];
-    cropController.aspectRatioLockDimensionSwapEnabled = YES;
     [cropController presentAnimatedFromParentViewController:self
                                                   fromImage:self.imageView.image
                                                    fromView:nil

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -81,6 +81,7 @@
     TOCropViewController *cropController = [[TOCropViewController alloc] initWithCroppingStyle:self.croppingStyle image:self.image];
     cropController.delegate = self;
     CGRect viewFrame = [self.view convertRect:self.imageView.frame toView:self.navigationController.view];
+    cropController.aspectRatioLockDimensionSwapEnabled = YES;
     [cropController presentAnimatedFromParentViewController:self
                                                   fromImage:self.imageView.image
                                                    fromView:nil

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -183,7 +183,7 @@ public class CropViewController: UIViewController, TOCropViewControllerDelegate 
      
      Default is false.
      */
-    var aspectRatioLockDimensionSwapEnabled: Bool {
+    public var aspectRatioLockDimensionSwapEnabled: Bool {
         set { toCropViewController.aspectRatioLockDimensionSwapEnabled = newValue }
         get { return toCropViewController.aspectRatioLockDimensionSwapEnabled }
     }

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -179,6 +179,16 @@ public class CropViewController: UIViewController, TOCropViewControllerDelegate 
     }
     
     /**
+     If true, a custom aspect ratio is set, and the aspectRatioLockEnabled is set to true, the crop box will swap it's dimensions depending on portrait or landscape sized images.  This value also controls whether the dimensions can swap when the image is rotated.
+     
+     Default is false.
+     */
+    var aspectRatioLockDimensionSwapEnabled: Bool {
+        set { toCropViewController.aspectRatioLockDimensionSwapEnabled = newValue }
+        get { return toCropViewController.aspectRatioLockDimensionSwapEnabled }
+    }
+    
+    /**
      If true, tapping the reset button will also reset the aspect ratio back to the image
      default ratio. Otherwise, the reset will just zoom out to the current aspect ratio.
      

--- a/TOCropViewController.podspec
+++ b/TOCropViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'TOCropViewController'
-  s.version  = '2.3.6'
+  s.version  = '2.3.7'
   s.license  =  { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A view controller that enables cropping and rotation of UIImage objects.'
   s.homepage = 'https://github.com/TimOliver/TOCropViewController'


### PR DESCRIPTION
Make dimension swap apply to rotating images in crop.  Expose the property to swift.  Add an extra method for specifying scale for UIImage+CropRotate.

I'm going to be using this fork for my own use, but I figured I'd ask if you'd like to get this merged into your repo too.  I can tweak or change anything small, but for now I'm just implementing the quick and dirty solution mentioned in #51 for aspect ratio locking dimension swap because that's what I need at the moment.  I think the animation looks adequate for now.  It could use a tweak so the image only scales up if necessary avoiding endless zoom in on repeated rotation, but I haven't quite figured out how to do that properly without rewriting the animation.

If you'd like to discuss further, cool.  If not, that's totally okay too and I'd completely understand that you might not want the changes.  If you are interested, I'll do some more robust testing with split screen and iPad and such, as mentioned in the contributing guidelines.