### PR TITLE
Fix crash problem after removing UImage scale

### DIFF
--- a/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Models/UIImage+CropRotate.m
@@ -31,7 +31,7 @@
             alphaInfo == kCGImageAlphaPremultipliedFirst || alphaInfo == kCGImageAlphaPremultipliedLast);
 }
 
-- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular scale:(CGFloat)scale
+- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
 {
     UIImage *croppedImage = nil;
     UIGraphicsBeginImageContextWithOptions(frame.size, ![self hasAlpha] && !circular, self.scale);
@@ -66,7 +66,7 @@
     }
     UIGraphicsEndImageContext();
     
-    return [UIImage imageWithCGImage:croppedImage.CGImage scale:scale orientation:UIImageOrientationUp];
+    return [UIImage imageWithCGImage:croppedImage.CGImage scale: self.scale orientation:UIImageOrientationUp];
 }
 
 


### PR DESCRIPTION
Using original image scale instead. 
The example code can be compiled without any crash