### PR TITLE
store the actual initial crop box size for correct checking of resetable state

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -341,7 +341,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     [self captureStateForImageRotation];
     
     //save the size for checking if we're in a resettable state
-    self.originalCropBoxSize = self.resetAspectRatioEnabled ? scaledImageSize : cropBoxSize;
+    self.originalCropBoxSize = self.resetAspectRatioEnabled ? scaledImageSize : self.cropBoxFrame.size;
     self.originalContentOffset = self.scrollView.contentOffset;
     
     [self checkForCanReset];


### PR DESCRIPTION
I had the problem, that the reset button was always initially enabled without any actions performed.
Turned out that it only happens in special cases.

I am cropping images on an iPhone 8 with an aspect ration of 1260:624.
In the `layoutInitialImage` method the `cropBoxSize` is calculated as 347:169, the setter for the `cropBoxFrame` does some modifications and sets an actual value of 346:169.

Later the `originalCropBoxSize` is stored, but the initially calculated value is stored, not the one the frame was actually set to. (Correction of 1px is missing).

This leads to a return of true in the `checkForCanReset` method as the current set frame size does not match the `originalCropBoxSize`.

 In the `layoutInitialImage` method the actual set value for the cropBoxSize needs to be stored for later comparison.



