### PR TITLE
Discard changes confirmation alert

### DIFF
--- a/Objective-C/TOCropViewController/Resources/Base.lproj/TOCropViewControllerLocalizable.strings
+++ b/Objective-C/TOCropViewController/Resources/Base.lproj/TOCropViewControllerLocalizable.strings
@@ -3,3 +3,5 @@
 "Reset" = "Reset";
 "Original" = "Original";
 "Square" = "Square";
+"Yes" = "Yes";
+"No" = "No";

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -244,6 +244,10 @@
 @property (nullable, nonatomic, strong) NSArray<UIActivityType> *excludedActivityTypes;
 
 /**
+ The aspect ratios which user can select in the actionsheet
+ */
+@property (nullable, nonatomic, strong) NSArray <NSNumber *> *allowedAspectRatios;
+/**
  When the user hits cancel, or completes a
  UIActivityViewController operation, this block will be called,
  giving you a chance to manually dismiss the view controller

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -99,6 +99,15 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         // Default initial behaviour
         _aspectRatioPreset = TOCropViewControllerAspectRatioPresetOriginal;
         _toolbarPosition = TOCropViewControllerToolbarPositionBottom;
+        
+        _allowedAspectRatios = @[@(TOCropViewControllerAspectRatioPresetOriginal),
+                                @(TOCropViewControllerAspectRatioPresetSquare),
+                                @(TOCropViewControllerAspectRatioPreset3x2),
+                                @(TOCropViewControllerAspectRatioPreset5x3),
+                                @(TOCropViewControllerAspectRatioPreset4x3),
+                                @(TOCropViewControllerAspectRatioPreset5x4),
+                                @(TOCropViewControllerAspectRatioPreset7x5),
+                                @(TOCropViewControllerAspectRatioPreset16x9)];
     }
 	
     return self;
@@ -580,14 +589,21 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 	NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
+    NSArray *portraitRatioTitles = @[originalButtonTitle, squareButtonTitle, @"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"];
+    NSArray *landscapeRatioTitles = @[originalButtonTitle, squareButtonTitle, @"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"];
+    
     NSMutableArray *items = [NSMutableArray array];
-    [items addObject:originalButtonTitle];
-    [items addObject:squareButtonTitle];
     if (verticalCropBox) {
-        [items addObjectsFromArray:@[@"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"]];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            NSInteger index = [aspectRatio integerValue];
+            [items addObject:portraitRatioTitles[index]];
+        }
     }
     else {
-        [items addObjectsFromArray:@[@"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"]];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            NSInteger index = [aspectRatio integerValue];
+            [items addObject:landscapeRatioTitles[index]];
+        }
     }
     
     //Present via a UIAlertController if >= iOS 8
@@ -597,13 +613,12 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         
         //Add each item to the alert controller
         NSInteger i = 0;
-        for (NSString *item in items) {
-            UIAlertAction *action = [UIAlertAction actionWithTitle:item style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [self setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)i animated:YES];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            UIAlertAction *action = [UIAlertAction actionWithTitle:items[i] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [self setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)[aspectRatio integerValue] animated:YES];
                 self.aspectRatioLockEnabled = YES;
             }];
             [alertController addAction:action];
-            
             i++;
         }
         

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -589,6 +589,8 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 	NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
+    
+    // Ratio titles according to the order of enum TOCropViewControllerAspectRatioPreset
     NSArray *portraitRatioTitles = @[originalButtonTitle, squareButtonTitle, @"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"];
     NSArray *landscapeRatioTitles = @[originalButtonTitle, squareButtonTitle, @"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"];
     

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -134,6 +134,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) NSInteger angle;
 
+
+/**
+ True if the original angle set before the crop view is shown doesn't equal to the latest angle
+ */
+@property (nonatomic, readonly) BOOL angleChanged;
+
 /**
  Hide all of the crop elements for transition animations 
  */

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -107,6 +107,9 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
 @property (nonatomic, assign) NSInteger restoreAngle;
 @property (nonatomic, assign) CGRect    restoreImageCropFrame;
 
+/* Angle set on the crop view before it was presented */
+@property (nonatomic, assign) NSInteger initialAngle;
+
 /* Set to YES once `performInitialLayout` is called. This lets pending properties get queued until the view
  has been properly set up in its parent. */
 @property (nonatomic, assign) BOOL initialSetupPerformed;
@@ -148,6 +151,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     self.resetAspectRatioEnabled = !circularMode;
     self.restoreImageCropFrame = CGRectZero;
     self.restoreAngle = 0;
+    self.initialAngle = 0;
     self.cropAdjustingDelay = kTOCropTimerDuration;
     self.cropViewPadding = kTOCropViewPadding;
     self.maximumZoomScale = kTOMaximumZoomScale;
@@ -1198,6 +1202,21 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     }
 }
 
+- (BOOL)angleChanged {
+    NSInteger tmpAngle = self.angle;
+    NSInteger tmpInitialAngle = self.initialAngle;
+    
+    if (tmpAngle < 0) {
+        tmpAngle += 360;
+    }
+    
+    if (tmpInitialAngle < 0) {
+        tmpInitialAngle += 360;
+    }
+    
+    return tmpAngle % 360 != tmpInitialAngle % 360;
+}
+
 - (void)setAngle:(NSInteger)angle
 {
     //The initial layout would not have been performed yet.
@@ -1208,6 +1227,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     }
     
     if (!self.initialSetupPerformed) {
+        self.initialAngle = newAngle;
         self.restoreAngle = newAngle;
         return;
     }

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -50,6 +50,11 @@
     // -- Uncomment this line of code to place the toolbar at the top of the view controller --
     //cropController.toolbarPosition = TOCropViewControllerToolbarPositionTop;
     
+    // -- Uncomment this line of code to include only certain type of preset ratios
+    //cropController.allowedAspectRatios = @[@(TOCropViewControllerAspectRatioPresetOriginal),
+    //                                       @(TOCropViewControllerAspectRatioPresetSquare),
+    //                                       @(TOCropViewControllerAspectRatioPreset3x2)];
+    
     //cropController.rotateButtonsHidden = YES;
     //cropController.rotateClockwiseButtonHidden = NO;
     


### PR DESCRIPTION
Referring Issue #259 

Added a 'Discard Changes?' confirmation alert when user tap 'Cancel' after making changes.

<img width="216" alt="discard" src="https://user-images.githubusercontent.com/3954625/46352056-71fd9c80-c68b-11e8-9ec9-e374bbc02368.png">

