### PR TITLE
Added property 'zoomEnabled' to enable / disable zooming of image

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -189,6 +189,14 @@
  */
 @property (nonatomic, assign) BOOL resetAspectRatioEnabled;
 
+
+/**
+ If true, the scroll view containing the image can be zoomed.
+ 
+ Default is YES
+ */
+@property (nonatomic, assign) BOOL zoomEnabled;
+
 /**
  The position of the Toolbar the default value is `TOCropViewControllerToolbarPositionBottom`.
  */

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -244,6 +244,10 @@
 @property (nullable, nonatomic, strong) NSArray<UIActivityType> *excludedActivityTypes;
 
 /**
+ The aspect ratios which user can select in the actionsheet
+ */
+@property (nullable, nonatomic, strong) NSArray <NSNumber *> *allowedAspectRatios;
+/**
  When the user hits cancel, or completes a
  UIActivityViewController operation, this block will be called,
  giving you a chance to manually dismiss the view controller

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -99,6 +99,15 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         // Default initial behaviour
         _aspectRatioPreset = TOCropViewControllerAspectRatioPresetOriginal;
         _toolbarPosition = TOCropViewControllerToolbarPositionBottom;
+        
+        _allowedAspectRatios = @[@(TOCropViewControllerAspectRatioPresetOriginal),
+                                @(TOCropViewControllerAspectRatioPresetSquare),
+                                @(TOCropViewControllerAspectRatioPreset3x2),
+                                @(TOCropViewControllerAspectRatioPreset5x3),
+                                @(TOCropViewControllerAspectRatioPreset4x3),
+                                @(TOCropViewControllerAspectRatioPreset5x4),
+                                @(TOCropViewControllerAspectRatioPreset7x5),
+                                @(TOCropViewControllerAspectRatioPreset16x9)];
     }
 	
     return self;
@@ -580,14 +589,21 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 	NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
+    NSArray *portraitRatioTitles = @[originalButtonTitle, squareButtonTitle, @"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"];
+    NSArray *landscapeRatioTitles = @[originalButtonTitle, squareButtonTitle, @"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"];
+    
     NSMutableArray *items = [NSMutableArray array];
-    [items addObject:originalButtonTitle];
-    [items addObject:squareButtonTitle];
     if (verticalCropBox) {
-        [items addObjectsFromArray:@[@"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"]];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            NSInteger index = [aspectRatio integerValue];
+            [items addObject:portraitRatioTitles[index]];
+        }
     }
     else {
-        [items addObjectsFromArray:@[@"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"]];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            NSInteger index = [aspectRatio integerValue];
+            [items addObject:landscapeRatioTitles[index]];
+        }
     }
     
     //Present via a UIAlertController if >= iOS 8
@@ -597,13 +613,12 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         
         //Add each item to the alert controller
         NSInteger i = 0;
-        for (NSString *item in items) {
-            UIAlertAction *action = [UIAlertAction actionWithTitle:item style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [self setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)i animated:YES];
+        for(NSNumber *aspectRatio in _allowedAspectRatios){
+            UIAlertAction *action = [UIAlertAction actionWithTitle:items[i] style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [self setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)[aspectRatio integerValue] animated:YES];
                 self.aspectRatioLockEnabled = YES;
             }];
             [alertController addAction:action];
-            
             i++;
         }
         

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -589,6 +589,8 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 	NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
+    
+    // Ratio titles according to the order of enum TOCropViewControllerAspectRatioPreset
     NSArray *portraitRatioTitles = @[originalButtonTitle, squareButtonTitle, @"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"];
     NSArray *landscapeRatioTitles = @[originalButtonTitle, squareButtonTitle, @"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"];
     

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -99,6 +99,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         // Default initial behaviour
         _aspectRatioPreset = TOCropViewControllerAspectRatioPresetOriginal;
         _toolbarPosition = TOCropViewControllerToolbarPositionBottom;
+        _zoomEnabled = YES;
         
         _allowedAspectRatios = @[@(TOCropViewControllerAspectRatioPresetOriginal),
                                 @(TOCropViewControllerAspectRatioPresetSquare),
@@ -193,7 +194,10 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     
     // Re-enable translucency now that the animation has completed
     self.cropView.simpleRenderMode = NO;
-
+    
+    // Scrollview.pinchGesture.enabled must be called in viewDidAppear or later, else system will reset it to YES
+    [self.cropView setZoomable: self.zoomEnabled];
+    
     // Now that the presentation animation will have finished, animate
     // the status bar fading out, and if present, the title label fading in
     void (^updateContentBlock)(void) = ^{

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -258,6 +258,13 @@ The minimum croping aspect ratio. If set, user is prevented from setting croppin
  */
 - (void)moveCroppedContentToCenterAnimated:(BOOL)animated;
 
+
+/**
+ Enable / Disable zooming of the image
+
+ @param zoomable Whether the zooming of image is allowed
+ */
+- (void)setZoomable:(BOOL)zoomable;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -1378,6 +1378,10 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     }];
 }
 
+- (void)setZoomable:(BOOL)zoomable{
+    self.scrollView.pinchGestureRecognizer.enabled = zoomable;
+}
+
 - (void)setAspectRatio:(CGSize)aspectRatio
 {
     [self setAspectRatio:aspectRatio animated:NO];

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -50,6 +50,11 @@
     // -- Uncomment this line of code to place the toolbar at the top of the view controller --
     //cropController.toolbarPosition = TOCropViewControllerToolbarPositionTop;
     
+    // -- Uncomment this line of code to include only certain type of preset ratios
+    //cropController.allowedAspectRatios = @[@(TOCropViewControllerAspectRatioPresetOriginal),
+    //                                       @(TOCropViewControllerAspectRatioPresetSquare),
+    //                                       @(TOCropViewControllerAspectRatioPreset3x2)];
+    
     //cropController.rotateButtonsHidden = YES;
     //cropController.rotateClockwiseButtonHidden = NO;
     


### PR DESCRIPTION
Issue Referenced : #290 

Set the `zoomEnabled` property of TOCropViewController to `NO` to disable zooming.

`cropController.zoomEnabled = NO;`