### PR TITLE
Fix inset error when toolbar position is top

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -364,7 +364,12 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     // If there is no title text, inset the top of the content as high as possible
     if (!self.titleLabel.text.length) {
         if (self.verticalLayout) {
+          if (self.toolbarPosition == TOCropViewControllerToolbarPositionTop) {
+            self.cropView.cropRegionInsets = UIEdgeInsetsMake(0.0f, 0.0f, insets.bottom, 0.0f);
+          }
+          else { // Add padding to the top otherwise
             self.cropView.cropRegionInsets = UIEdgeInsetsMake(insets.top, 0.0f, 0.0, 0.0f);
+          }
         }
         else {
             self.cropView.cropRegionInsets = UIEdgeInsetsMake(0.0f, 0.0f, insets.bottom, 0.0f);


### PR DESCRIPTION
When  you set `cropController.toolbarPosition = TOCropViewControllerToolbarPositionTop;`
As the default was Bottom, cropView insets set incorrectly, so it violates bottom safe layout inset and 
top insets became double.

This fix that bug.