### PR TITLE
Makes delegate weak instead strong reference at CropViewController.

### DIFF
--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -95,7 +95,7 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
      The view controller's delegate that will receive the resulting
      cropped image, as well as crop information.
     */
-    public var delegate: CropViewControllerDelegate? {
+    public weak var delegate: CropViewControllerDelegate? {
         didSet { self.setUpDelegateHandlers() }
     }
     


### PR DESCRIPTION
Hi! 

I found issue with retain cycle in the pod.
It's **strong** `delegate` property at `CropViewController` class.
Changed to `weak` reference.