### PR TITLE
Update README to include better Carthage Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ iOS 8.0 or above
 
 ## Installation
 
-#### As a CocoaPods Dependency
-
+<details>
+<summary>**CocoaPods**</summary>
 ##### Objective-C
 
 Add the following to your Podfile:
@@ -56,9 +56,10 @@ Add the following to your Podfile:
 ``` ruby
 pod 'CropViewController'
 ```
+</details>
 
-
-#### As a Carthage Dependency
+<details>
+<summary>**Carthage**</summary>
 
 1. Add the following to your Cartfile:
 ``` 
@@ -67,21 +68,19 @@ github "TimOliver/TOCropViewController"
 
 2. Run `carthage update`
 
-#### Objective-C
-
-3. From the `Carthage/Build` folder, import just `TOCropViewController.framework` into your app's project in Xcode. 
-
-#### Swift
-
-3. From the `Carthage/Build` folder, import just `CropViewController.framework` into your app's project in Xcode. 
+3. From the `Carthage/Build` folder, import one of the two frameworks into your Xcode project. For Objective-C projects, import just `TOCropViewController.framework`  and for Swift, import `CropViewController.framework` instead. Each framework is separate; you do not need to import both.
 
 4. Follow the remaining steps on [Getting Started with Carthage](https://github.com/Carthage/Carthage#getting-started) to finish integrating the framework.
 
-#### Manual Installation
+</details>
+
+<details>
+<summary>**Manual Installation**</summary>
 
 All of the necessary source and resource files for `TOCropViewController` are in `Objective-C/TOCropViewController`, and all of the necessary Swift files are in `Swift/CropViewController`.
 
 For Objective-C projects, copy just the `TOCropViewController` directory to your Xcode project. For Swift projects, copy both `TOCropViewController` and `CropViewController` to your project.
+</details>
 
 ## Examples
 Using `TOCropViewController` is very straightforward. Simply create a new instance passing the `UIImage` object you wish to crop, and then present it modally on the screen.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ iOS 8.0 or above
 ## Installation
 
 <details>
-<summary>**CocoaPods**</summary>
+  <summary><h3>CocoaPods</h3></summary>
 ##### Objective-C
 
 Add the following to your Podfile:

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ iOS 8.0 or above
 ## Installation
 
 <details>
-  <summary><h3>CocoaPods</h3></summary>
-##### Objective-C
+  <summary><strong>CocoaPods</strong></summary>
+  <h4>Objective-C</h4>
 
 Add the following to your Podfile:
 ``` ruby
 pod 'TOCropViewController'
 ```
 
-##### Swift
+<h4>Swift</h4>
 
 Add the following to your Podfile:
 ``` ruby
@@ -59,7 +59,7 @@ pod 'CropViewController'
 </details>
 
 <details>
-<summary>**Carthage**</summary>
+  <summary><strong>Carthage</strong></summary>
 
 1. Add the following to your Cartfile:
 ``` 
@@ -75,7 +75,7 @@ github "TimOliver/TOCropViewController"
 </details>
 
 <details>
-<summary>**Manual Installation**</summary>
+<summary><strong>Manual Installation</strong></summary>
 
 All of the necessary source and resource files for `TOCropViewController` are in `Objective-C/TOCropViewController`, and all of the necessary Swift files are in `Swift/CropViewController`.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ While `TOCropViewController` prefers to be presented modally, it can also be pus
 
 For a complete working example, check out the sample apps included in this repo.
 
-### Basic Implementation
+<details>
+<summary><strong>Basic Implementation</strong></summary>
 
 #### Swift
 ```swift
@@ -123,8 +124,10 @@ func cropViewController(_ cropViewController: CropViewController, didCropToImage
   // 'image' is the newly cropped version of the original image
 }
 ```
+</details>
 
-### Making a Circular Cropped Image
+<details>
+<summary><strong>Making a Circular Cropped Image</strong></summary>
 
 #### Swift
 ```swift
@@ -157,8 +160,10 @@ cropViewController.delegate = self;
 // 'image' is the newly cropped, circular version of the original image
 }
 ```
+</details>
 
-### Sharing Cropped Images Via a Share Sheet
+<details>
+<summary><strong>Sharing Cropped Images Via a Share Sheet</strong></summary>
 
 #### Swift
 ```swift
@@ -181,8 +186,11 @@ func presentCropViewController() {
   [self presentViewController:cropViewController animated:YES completion:nil];
 }
 ```
+</details>
 
-### Presenting With a Custom Animation
+<details>
+<summary><strong>Presenting With a Custom Animation</strong></summary>
+
 Optionally, `TOCropViewController` also supports a custom presentation animation where an already-visible copy of the image will zoom in to fill the screen.
 
 #### Swift
@@ -214,6 +222,7 @@ func presentCropViewController() {
   [cropViewController presentAnimatedFromParentViewController:self fromFrame:frame completion:nil];
 }
 ```
+</details>
 
 ## Architecture of `TOCropViewController`
 While traditional cropping UI implementations will usually just have a dimming view with a square hole cut out of the middle, `TOCropViewController` goes about its implementation a little differently.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ iOS 8.0 or above
 
 <details>
   <summary><strong>CocoaPods</strong></summary>
+  
   <h4>Objective-C</h4>
 
 Add the following to your Podfile:

--- a/README.md
+++ b/README.md
@@ -60,10 +60,22 @@ pod 'CropViewController'
 
 #### As a Carthage Dependency
 
-Add the following to your Cartfile:
+1. Add the following to your Cartfile:
 ``` 
 github "TimOliver/TOCropViewController"
 ```
+
+2. Run `carthage update`
+
+#### Objective-C
+
+3. From the `Carthage/Build` folder, import just `TOCropViewController.framework` into your app's project in Xcode. 
+
+#### Swift
+
+3. From the `Carthage/Build` folder, import just `CropViewController.framework` into your app's project in Xcode. 
+
+4. Follow the remaining steps on [Getting Started with Carthage](https://github.com/Carthage/Carthage#getting-started) to finish integrating the framework.
 
 #### Manual Installation
 


### PR DESCRIPTION
* Added more verbose instructions on how to install the framework via Carthage depending on language.
* Made instructions section collapsable to keep the README size smaller.
* Also added collapsable syntax to the sample code.