### PR TITLE
Clean up Custom Aspect Ratio Name feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,22 @@ x.y.z Release Notes (yyyy-MM-dd)
 ## Added
 - Swift 5.0 Support ([#343](https://github.com/TimOliver/TOCropViewController/pull/343))
 - Persian Language Support ([#337](https://github.com/TimOliver/TOCropViewController/pull/337))
+- Added `customAspectRatioName` property to expose the custom aspect ratio as a selectable choice ([344](https://github.com/TimOliver/TOCropViewController/pull/344))
 
 2.4.0 Release Notes (2018-12-01)
 =============================================================
 
 ## Added
 - Swift 4.2 Support
-- Romanian and Hungarian localizations
-- The ability to show only certain aspect ratios
-- A setting to allow confirmation before cancelling a crop
+- Romanian and Hungarian localizations.
+- The ability to show only certain aspect ratios.
+- A setting to allow confirmation before cancelling a crop.
 
 ## Fixed
 - Fixed layout issue on the new iPad Pro
-- Fixed issues with the aspect ratio settings when zooming out
-- Fixed an issue when rotating images would sometimes break
-- A bug where the completion handler of the cropping operation wouldn't fire
+- Fixed issues with the aspect ratio settings when zooming out.
+- Fixed an issue when rotating images would sometimes break.
+- A bug where the completion handler of the cropping operation wouldn't fire.
 
 ## Removed
 - iOS 7 Support

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -152,7 +152,8 @@
 @property (nonatomic, assign) CGSize customAspectRatio;
 
 /**
- Give the custom aspect ratio a name. Default: "Custom"
+ If this is set alongside `customAspectRatio`, the custom aspect ratio
+ will be shown as a selectable choice in the list of aspect ratios. (Default is `nil`)
  */
 @property (nullable, nonatomic, copy) NSString *customAspectRatioName;
 

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -598,11 +598,11 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
             [ratioValues addObject:allowedRatio];
         }
     }
-    //Add Custom as Selectable AspectRatio
-    if (!CGSizeEqualToSize(CGSizeZero, _customAspectRatio)) {
-	if (_customAspectRatioName.length > 0) [itemStrings addObject:_customAspectRatioName];
-	else [itemStrings addObject:@"Custom"];
-	[ratioValues addObject:@(TOCropViewControllerAspectRatioPresetCustom)];
+    
+    // If a custom aspect ratio is provided, and a custom name has been given to it, add it as a visible choice
+    if (self.customAspectRatioName.length > 0 && !CGSizeEqualToSize(CGSizeZero, self.customAspectRatio)) {
+        [itemStrings addObject:self.customAspectRatioName];
+        [ratioValues addObject:@(TOCropViewControllerAspectRatioPresetCustom)];
     }
 
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];


### PR DESCRIPTION
Cleaned up the custom aspect ratio name feature  introduced in #344 so it won't be visible unless the developer explicitly sets a name.