### PR TITLE
Call super's designated initializer on initialization

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -75,7 +75,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 {
     NSParameterAssert(image);
 
-    self = [super init];
+    self = [super initWithNibName:nil bundle:nil];
     if (self) {
         // Init parameters
         _image = image;


### PR DESCRIPTION
The initializer `initWithCroppingStyle:image:` calls a `super` initializer that is not a designated initializer. This leads to a crash on initialization of subclasses implemented in Swift that don't provide a custom `init()`.

To reproduce the issue, create a subclass in Swift as follows:

```
class CropViewController: TOCropViewController {
  init(image: UIImage) {
    super.init(croppingStyle: .default, image: image)
  }
  /* ... */
}
```

A call to `init(image:)` will throw an exception.

The PR fixes this issue.