### PR TITLE
Ensured explict fullscreen handling of Swift controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ x.y.z Release Notes (yyyy-MM-dd)
 
 * Brazilian Portuguese Language Support ([#380](https://github.com/TimOliver/TOCropViewController/issues/380))
 
+## Fixed
+
+* A visual glitch that would occur in iOS 13 because the Swift view controller wasn't explicitly marked as full screen.
+
 2.5.1 Release Notes (2019-07-08)
 =============================================================
 

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -557,6 +557,7 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
 
 extension CropViewController {
     fileprivate func setUpCropController() {
+        modalPresentationStyle = .fullScreen
         addChild(toCropViewController)
         transitioningDelegate = (toCropViewController as! UIViewControllerTransitioningDelegate)
         toCropViewController.delegate = self

--- a/Swift/CropViewControllerExample/ViewController.swift
+++ b/Swift/CropViewControllerExample/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
         guard let image = (info[UIImagePickerController.InfoKey.originalImage] as? UIImage) else { return }
         
         let cropController = CropViewController(croppingStyle: croppingStyle, image: image)
-        cropController.modalPresentationStyle = .fullScreen
+        //cropController.modalPresentationStyle = .fullScreen
         cropController.delegate = self
         
         // Uncomment this if you wish to provide extra instructions via a title label


### PR DESCRIPTION
While this issue was partially fixed by another PR, I decided to explicitly ensure the Swift version of `TOCropViewController` also forces full screen since the behavior changed in iOS 13.