### PR TITLE
Fixed image snapping glitch on non-Face ID devices.

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1197,7 +1197,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
 - (BOOL)statusBarHidden
 {
-    // Defer behavioir to the hosting navigation controller
+    // Defer behaviour to the hosting navigation controller
     if (self.navigationController) {
         return self.navigationController.prefersStatusBarHidden;
     }
@@ -1217,6 +1217,14 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     CGFloat statusBarHeight = 0.0f;
     if (@available(iOS 11.0, *)) {
         statusBarHeight = self.view.safeAreaInsets.top;
+
+        // On non-Face ID devices, always disregard the top inset
+        // unless we explicitly set the status bar to be visible.
+        if (self.statusBarHidden &&
+            self.view.safeAreaInsets.bottom <= FLT_EPSILON)
+        {
+            statusBarHeight = 0.0f;
+        }
     }
     else {
         if (self.statusBarHidden) {
@@ -1235,12 +1243,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     UIEdgeInsets insets = UIEdgeInsetsZero;
     if (@available(iOS 11.0, *)) {
         insets = self.view.safeAreaInsets;
-
-        // Since iPhone X insets are always 44, check if this is merely
-        // accounting for a non-X status bar and cancel it
-        if (insets.top <= 40.0f + FLT_EPSILON) {
-            insets.top = self.statusBarHeight;
-        }
+        insets.top = self.statusBarHeight;
     }
     else {
         insets.top = self.statusBarHeight;


### PR DESCRIPTION
On iOS 13, the expected inset values of `safeAreaInsets` changed which created a snapping effect when devices that don't have Face ID played the opening animation or device rotations.

I've fixed the issue on iOS 13, but I still need to test this didn't regress on iOS 12 and below.