### PR TITLE
Enable to hide "Done"/"Cancel" button.

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -249,6 +249,20 @@
  */
 @property (nonatomic, assign) BOOL aspectRatioPickerButtonHidden;
 
+/**
+ When enabled, hides the 'Done' button on the toolbar.
+
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL doneButtonHidden;
+
+/**
+ When enabled, hides the 'Cancel' button on the toolbar.
+
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL cancelButtonHidden;
+
 /** 
  If `showActivitySheetOnDone` is true, then these activity items will 
  be supplied to that UIActivityViewController in addition to the 

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1133,6 +1133,26 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self.toolbar.clampButtonHidden;
 }
 
+- (void)setDoneButtonHidden:(BOOL)doneButtonHidden
+{
+    self.toolbar.doneButtonHidden = doneButtonHidden;
+}
+
+- (BOOL)doneButtonsHidden
+{
+    return self.toolbar.doneButtonHidden;
+}
+
+- (void)setCancelButtonHidden:(BOOL)cancelButtonHidden
+{
+    self.toolbar.cancelButtonHidden = cancelButtonHidden;
+}
+
+- (BOOL)cancelButtonsHidden
+{
+    return self.toolbar.cancelButtonHidden;
+}
+
 - (void)setResetAspectRatioEnabled:(BOOL)resetAspectRatioEnabled
 {
     self.cropView.resetAspectRatioEnabled = resetAspectRatioEnabled;

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1138,7 +1138,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     self.toolbar.doneButtonHidden = doneButtonHidden;
 }
 
-- (BOOL)doneButtonsHidden
+- (BOOL)doneButtonHidden
 {
     return self.toolbar.doneButtonHidden;
 }
@@ -1148,7 +1148,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     self.toolbar.cancelButtonHidden = cancelButtonHidden;
 }
 
-- (BOOL)cancelButtonsHidden
+- (BOOL)cancelButtonHidden
 {
     return self.toolbar.cancelButtonHidden;
 }

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.h
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.h
@@ -72,6 +72,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL rotateCounterclockwiseButtonHidden;
 @property (nonatomic, assign) BOOL rotateClockwiseButtonHidden;
 @property (nonatomic, assign) BOOL resetButtonHidden;
+@property (nonatomic, assign) BOOL doneButtonHidden;
+@property (nonatomic, assign) BOOL cancelButtonHidden;
 
 /* Enable the reset button */
 @property (nonatomic, assign) BOOL resetButtonEnabled;

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -144,10 +144,10 @@
     BOOL verticalLayout = (CGRectGetWidth(self.bounds) < CGRectGetHeight(self.bounds));
     CGSize boundsSize = self.bounds.size;
     
-    self.cancelIconButton.hidden = (!verticalLayout);
-    self.cancelTextButton.hidden = (verticalLayout);
-    self.doneIconButton.hidden   = (!verticalLayout);
-    self.doneTextButton.hidden   = (verticalLayout);
+    self.cancelIconButton.hidden = self.cancelButtonHidden || (!verticalLayout);
+    self.cancelTextButton.hidden = self.cancelButtonHidden || (verticalLayout);
+    self.doneIconButton.hidden   = self.doneButtonHidden || (!verticalLayout);
+    self.doneTextButton.hidden   = self.doneButtonHidden || (verticalLayout);
 
     CGRect frame = self.bounds;
     frame.origin.x -= self.backgroundViewOutsets.left;
@@ -366,6 +366,22 @@
 - (void)setResetButtonEnabled:(BOOL)resetButtonEnabled
 {
     self.resetButton.enabled = resetButtonEnabled;
+}
+
+- (void)setDoneButtonHidden:(BOOL)doneButtonHidden {
+    if (_doneButtonHidden == doneButtonHidden)
+        return;
+    
+    _doneButtonHidden = doneButtonHidden;
+    [self setNeedsLayout];
+}
+
+- (void)setCancelButtonHidden:(BOOL)cancelButtonHidden {
+    if (_cancelButtonHidden == cancelButtonHidden)
+        return;
+    
+    _cancelButtonHidden = cancelButtonHidden;
+    [self setNeedsLayout];
 }
 
 - (CGRect)doneButtonFrame

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -258,6 +258,26 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     }
     
     /**
+     When enabled, hides the 'Done' button on the toolbar.
+
+     Default is false.
+     */
+    public var doneButtonHidden: Bool {
+        set { toCropViewController.doneButtonHidden = newValue }
+        get { return toCropViewController.doneButtonHidden }
+    }
+    
+    /**
+     When enabled, hides the 'Cancel' button on the toolbar.
+
+     Default is false.
+     */
+    public var cancelButtonHidden: Bool {
+        set { toCropViewController.cancelButtonHidden = newValue }
+        get { return toCropViewController.cancelButtonHidden }
+    }
+
+    /**
      If `showActivitySheetOnDone` is true, then these activity items will
      be supplied to that UIActivityViewController in addition to the
      `TOActivityCroppedImageProvider` object.

--- a/Swift/CropViewControllerExample/ViewController.swift
+++ b/Swift/CropViewControllerExample/ViewController.swift
@@ -47,6 +47,10 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
         //cropController.doneButtonTitle = "Title"
         //cropController.cancelButtonTitle = "Title"
         
+        //cropController.toolbar.doneButtonHidden = true
+        //cropController.toolbar.cancelButtonHidden = true
+        //cropController.toolbar.clampButtonHidden = true
+
         self.image = image
         
         //If profile picture, push onto the same navigation stack


### PR DESCRIPTION
Following properties are added to hide done and cancel button.
These properties are useful for the user who want to use customized done/cancel button.
- doneButtonHidden
- cancelButtonHidden