### PR TITLE
Added 'cropsToSquare' option to crop image to square while showing circular overlay

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -143,7 +143,7 @@
 /**
   The option of cropping image to square while showing circular overlay
  */
-@property (nonatomic, assign) BOOL cropsToSquare;
+@property (nonatomic, assign, readwrite) BOOL cropsToSquare;
 
 /**
  A choice from one of the pre-defined aspect ratio presets

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -143,7 +143,7 @@
 /**
   The option of cropping image to square while showing circular overlay
  */
-@property (nonatomic, assign, readwrite) BOOL cropsToSquare;
+@property (nonatomic, assign) BOOL cropsToSquare;
 
 /**
  A choice from one of the pre-defined aspect ratio presets

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -141,6 +141,11 @@
 @property (nonatomic, readonly) TOCropViewCroppingStyle croppingStyle;
 
 /**
+  The option of cropping image to square while showing circular overlay
+ */
+@property (nonatomic, assign, readwrite) BOOL cropsToSquare;
+
+/**
  A choice from one of the pre-defined aspect ratio presets
  */
 @property (nonatomic, assign) TOCropViewControllerAspectRatioPreset aspectRatioPreset;

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -37,6 +37,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
 /* The cropping style of the crop view */
 @property (nonatomic, assign, readwrite) TOCropViewCroppingStyle croppingStyle;
+@property (nonatomic, assign, readwrite) BOOL cropsToSquare;
 
 /* Views */
 @property (nonatomic, strong) TOCropToolbar *toolbar;
@@ -901,10 +902,10 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 {
     CGRect cropFrame = self.cropView.imageCropFrame;
     NSInteger angle = self.cropView.angle;
-
+    
     //If desired, when the user taps done, show an activity sheet
     if (self.showActivitySheetOnDone) {
-        TOActivityCroppedImageProvider *imageItem = [[TOActivityCroppedImageProvider alloc] initWithImage:self.image cropFrame:cropFrame angle:angle circular:(self.croppingStyle == TOCropViewCroppingStyleCircular)];
+        TOActivityCroppedImageProvider *imageItem = [[TOActivityCroppedImageProvider alloc] initWithImage:self.image cropFrame:cropFrame angle:angle circular:(self.croppingStyle == TOCropViewCroppingStyleCircular && !self.cropsToSquare)];
         TOCroppedImageAttributes *attributes = [[TOCroppedImageAttributes alloc] initWithCroppedFrame:cropFrame angle:angle originalImageSize:self.image.size];
         
         NSMutableArray *activityItems = [@[imageItem, attributes] mutableCopy];
@@ -969,7 +970,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     BOOL isDidCropToImageCallbackAvailable = self.onDidCropToRect != nil;
 
     //If cropping circular and the circular generation delegate/block is implemented, call it
-    if (self.croppingStyle == TOCropViewCroppingStyleCircular && (isCircularImageDelegateAvailable || isCircularImageCallbackAvailable)) {
+    if (self.croppingStyle == TOCropViewCroppingStyleCircular && (isCircularImageDelegateAvailable || isCircularImageCallbackAvailable) && !self.cropsToSquare) {
         UIImage *image = [self.image croppedImageWithFrame:cropFrame angle:angle circularClip:YES];
         
         //Dispatch on the next run-loop so the animation isn't interuppted by the crop operation

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -902,7 +902,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 {
     CGRect cropFrame = self.cropView.imageCropFrame;
     NSInteger angle = self.cropView.angle;
-    
+
     //If desired, when the user taps done, show an activity sheet
     if (self.showActivitySheetOnDone) {
         TOActivityCroppedImageProvider *imageItem = [[TOActivityCroppedImageProvider alloc] initWithImage:self.image cropFrame:cropFrame angle:angle circular:(self.croppingStyle == TOCropViewCroppingStyleCircular && !self.cropsToSquare)];

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -37,7 +37,6 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
 /* The cropping style of the crop view */
 @property (nonatomic, assign, readwrite) TOCropViewCroppingStyle croppingStyle;
-@property (nonatomic, assign) BOOL cropsToSquare;
 
 /* Views */
 @property (nonatomic, strong) TOCropToolbar *toolbar;

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -37,7 +37,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
 /* The cropping style of the crop view */
 @property (nonatomic, assign, readwrite) TOCropViewCroppingStyle croppingStyle;
-@property (nonatomic, assign, readwrite) BOOL cropsToSquare;
+@property (nonatomic, assign) BOOL cropsToSquare;
 
 /* Views */
 @property (nonatomic, strong) TOCropToolbar *toolbar;

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -148,6 +148,13 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     }
     
     /**
+      The option of cropping image to square while showing circular overlay
+     */
+    public var cropsToSquare: Bool {
+        return toCropViewController.cropsToSquare
+    }
+    
+    /**
       A choice from one of the pre-defined aspect ratio presets
     */
     public var aspectRatioPreset: CropViewControllerAspectRatioPreset {

--- a/Swift/CropViewControllerExample/Info.plist
+++ b/Swift/CropViewControllerExample/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Crop and rotate your photos!</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,7 +43,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Crop and rotate your photos!</string>
 </dict>
 </plist>


### PR DESCRIPTION
Related to issue #197 , I added  'cropsToSquare' option of cropping image to square while showing circular overlay.
If you want to crop image as rect in circular cropping style, all you have to do is:
```swift
let cropViewController = CropViewController(croppingStyle: .circular, image: image)
cropViewController.cropsToSquare = true
```
#### Notice
If you set `.cropsToSquare` to `true`,  `didCropTo` delegate method is called and `didCropToCircularImage` delegate method is NOT called.