### PR TITLE
Add TOCropViewController import for SwiftPM

### DIFF
--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -20,6 +20,10 @@
 //  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#if canImport(TOCropViewController)
+import TOCropViewController
+#endif
+
 /**
  An enum containing all of the aspect ratio presets that this view controller supports
  */


### PR DESCRIPTION
Currently, SwiftPM's `CropViewController` module can't compiled, Because there are lots of error witch can't reference to `TOCropViewController` module
In SwiftPM, Each module should import explicitly.

But, In CocoaPods it has only one module that has Obj-C, Swift. So I wrap with canImport clause that CocoaPods build works too after this changes. 