### PR TITLE
Excludes include directory aliases

### DIFF
--- a/TOCropViewController.podspec
+++ b/TOCropViewController.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/TimOliver/TOCropViewController.git', :tag => s.version }
   s.platform = :ios, '8.0'
   s.source_files = 'Objective-C/TOCropViewController/**/*.{h,m}'
+  s.exclude_files = 'Objective-C/TOCropViewController/include/**/*.h'
   s.resource_bundles = {
     'TOCropViewControllerBundle' => ['Objective-C/TOCropViewController/**/*.lproj']
   }


### PR DESCRIPTION
We've been using this dependency at Artsy for a few months with CocoaPods, via [react-native-image-crop-picker](https://github.com/ivpusic/react-native-image-crop-picker), and have ran into problems with duplicate UUIDs and build warnings related to duplicated header files. I found #424 which seemed to describe the problem we were having and I think I have a solution.

The `Objective-C/TOCropViewController/include` directory seems to include a bunch of aliased header files, and a module map. These header files point to actual files, but they get included in the generated Pods Xcode project _twice_ (once for the original header, and once for the alias). This means that the deterministically-generated UUID will be duplicated (it's the same file) and the headers get included twice in the Xcode project. It seems these aliases are important for SPM so the easiest way to solve the problem is have CocoaPods ignore them.

My solution is to exclude those header aliases, while still including the module map, using the `exclude_files` in the podspec. I've tested this out locally and this fixes both the `pod install` warnings and build time Xcode warnings.

Let me know if I can clarify anything at all, and thank you for the really cool project 🙏 

Fixes #424.