### PR TITLE
Added .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+## Misc
+.DS_Store


### PR DESCRIPTION
Hey Tim.

Just did a fork and clone and the first thing I realised is that the gitignore is not ignoring the auto generated .DS_Store file. Usually most developers will have added this to the global gitignore. However, to prevent newbies who have not added this to their global gitignore, I have added this file to the project gitignore.

Hope it helps. :)
~ Aizat Omar