### PR TITLE
Dismiss or pop view controllers accordingly

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -887,11 +887,10 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
     // If neither callbacks were implemented, perform a default dismissing animation
     if (!isDelegateOrCallbackHandled) {
-        if (self.navigationController) {
+        if (self.navigationController && self.navigationController.viewControllers.count > 1) {
             [self.navigationController popViewControllerAnimated:YES];
         }
         else {
-            self.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
             [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         }
     }
@@ -939,8 +938,13 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
             }
             
             if (!isCallbackOrDelegateHandled) {
-                [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-                blockController.completionWithItemsHandler = nil;
+                if (self.navigationController != nil && self.navigationController.viewControllers.count > 1) {
+                    [self.navigationController popViewControllerAnimated:YES];
+                }
+                else {
+                    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+                    blockController.completionWithItemsHandler = nil;
+                }
             }
         };
 


### PR DESCRIPTION
Hello Tim!

Got caught up with Assassin's Creed Valhalla release yesterday! So sorry! I can't help it!

Anyway, here is my PR for improving the dismissing of the view controller in your default done and cancel handler.

I added a check to see if the view controller is embedded in a navigation controller. If it is the root of the navigation controller, dismiss the navigation controller. If it is not, then just pop the view controller.

If the view controller is presented modally without being embedded in a navigation controller, then just dismiss the view controller accordingly.

**Note:**
I see you have this on line 894:
```
self.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
```
I took the liberty of deleting this line because I am not sure why this is in the cancel handler but not in the done handler.

Please let me know if you still want this behavior. And maybe if you want to standardise it for both cancel and done.