### PR TITLE
Exclude headers in the Swift podspec #437

### DIFF
--- a/CropViewController.podspec
+++ b/CropViewController.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/TimOliver/TOCropViewController.git', :tag => s.version }
   s.platform = :ios, '8.0'
   s.source_files = 'Swift/CropViewController/**/*.{h,swift}', 'Objective-C/TOCropViewController/**/*.{h,m}'
+  s.exclude_files = 'Objective-C/TOCropViewController/include/**/*.h'
   s.resource_bundles = {
     'TOCropViewControllerBundle' => ['Objective-C/TOCropViewController/**/*.lproj']
   }


### PR DESCRIPTION
This is for issue: https://github.com/TimOliver/TOCropViewController/issues/437

Ash had the proper fix for this in: https://github.com/TimOliver/TOCropViewController/pull/432

The problem was the fix only got put in `TOCropViewController.podspec` instead of both that and `CropViewController.podspec` - thus the Swift loving folks were still seeing warnings in their `pod install`.