### PR TITLE
Fix dark png with white background

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -177,6 +177,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     
     //Background Image View
     self.backgroundImageView = [[UIImageView alloc] initWithImage:self.image];
+    self.backgroundImageView.backgroundColor = [UIColor colorWithWhite:1.0f alpha:1.0f];
     self.backgroundImageView.layer.minificationFilter = kCAFilterTrilinear;
     
     //Background container view
@@ -216,6 +217,7 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     [self addSubview:self.foregroundContainerView];
     
     self.foregroundImageView = [[UIImageView alloc] initWithImage:self.image];
+    self.foregroundImageView.backgroundColor =  [UIColor colorWithWhite:1.0f alpha:1.0f];
     self.foregroundImageView.layer.minificationFilter = kCAFilterTrilinear;
     [self.foregroundContainerView addSubview:self.foregroundImageView];
     


### PR DESCRIPTION
This PR applies white background to the images for show better dark pngs.

The native cropper of iOS do this for the images, so this change is for create a cropper like iOS cropper.

Native cropper white a black png:
![Simulator Screen Shot - iPhone 11 - 2020-11-17 at 12 53 39](https://user-images.githubusercontent.com/15233913/99387240-edeee900-28d3-11eb-8dce-93f32808af31.png)

With the PR:
![Simulator Screen Shot - iPhone 11 - 2020-11-17 at 12 51 36](https://user-images.githubusercontent.com/15233913/99387075-abc5a780-28d3-11eb-8424-0434ece7973a.png)
