### PR TITLE
Change iOS deployment target for Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,18 @@
 
 import PackageDescription
 
+var platforms: [SupportedPlatform] {
+    #if compiler(<5.3)
+        return [.iOS(.v8)]
+    #else
+        // Xcode 12 (which ships with Swift 5.3) drops support for iOS 8
+        return[.iOS(.v9)]
+    #endif
+}
+
 let package = Package(
     name: "TOCropViewController",
-    platforms: [.iOS(.v8)],
+    platforms: platforms,
     products: [
         .library(
             name: "TOCropViewController",


### PR DESCRIPTION
This removes the warning about iOS 8 no longer being supported in Xcode 12 while maintaining support for older versions of Xcode. Technically checking the compiler version isn’t an exact 1:1 for checking for Xcode version, but in practice should work in all scenarios.