### PR TITLE
Added SFSymbols to iOS 13 and above

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -288,12 +288,16 @@
         CGFloat padding = (maxLength - fixedSize * count) / (count + 1);
         
         for (NSInteger i = 0; i < count; i++) {
-            UIView *button = buttons[i];
+            UIButton *button = buttons[i];
             CGFloat sameOffset = horizontally ? fabs(CGRectGetHeight(containerRect)-CGRectGetHeight(button.bounds)) : fabs(CGRectGetWidth(containerRect)-CGRectGetWidth(button.bounds));
             CGFloat diffOffset = padding + i * (fixedSize + padding);
             CGPoint origin = horizontally ? CGPointMake(diffOffset, sameOffset) : CGPointMake(sameOffset, diffOffset);
             if (horizontally) {
                 origin.x += CGRectGetMinX(containerRect);
+                if (@available(iOS 13.0, *)) {
+                    UIImage *image = button.imageView.image;
+                    button.imageEdgeInsets = UIEdgeInsetsMake(0, 0, image.baselineOffsetFromBottom, 0);
+                }
             } else {
                 origin.y += CGRectGetMinY(containerRect);
             }
@@ -474,8 +478,9 @@
 + (UIImage *)rotateCCWImage
 {
     if (@available(iOS 13.0, *)) {
-        return [UIImage systemImageNamed:@"rotate.left.fill"
-                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+        return [[UIImage systemImageNamed:@"rotate.left.fill"
+                        withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]]
+                imageWithBaselineOffsetFromBottom:4];
     }
 
     UIImage *rotateImage = nil;
@@ -516,8 +521,9 @@
 + (UIImage *)rotateCWImage
 {
     if (@available(iOS 13.0, *)) {
-        return [UIImage systemImageNamed:@"rotate.right.fill"
-                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+        return [[UIImage systemImageNamed:@"rotate.right.fill"
+                        withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]]
+                imageWithBaselineOffsetFromBottom:4];
     }
 
     UIImage *rotateCCWImage = [self.class rotateCCWImage];
@@ -534,8 +540,9 @@
 + (UIImage *)resetImage
 {
     if (@available(iOS 13.0, *)) {
-        return [UIImage systemImageNamed:@"arrow.counterclockwise"
-                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+        return [[UIImage systemImageNamed:@"arrow.counterclockwise"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]]
+                imageWithBaselineOffsetFromBottom:0];;
     }
 
     UIImage *resetImage = nil;
@@ -583,8 +590,9 @@
 + (UIImage *)clampImage
 {
     if (@available(iOS 13.0, *)) {
-        return [UIImage systemImageNamed:@"aspectratio.fill"
-                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+        return [[UIImage systemImageNamed:@"aspectratio.fill"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]]
+                imageWithBaselineOffsetFromBottom:0];
     }
 
     UIImage *clampImage = nil;

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -78,7 +78,11 @@
                                                                   nil)
                      forState:UIControlStateNormal];
     [_doneTextButton setTitleColor:[UIColor colorWithRed:1.0f green:0.8f blue:0.0f alpha:1.0f] forState:UIControlStateNormal];
-    [_doneTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f]];
+    if (@available(iOS 13.0, *)) {
+        [_doneTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f weight:UIFontWeightMedium]];
+    } else {
+        [_doneTextButton.titleLabel setFont:[UIFont systemFontOfSize:17.0f]];
+    }
     [_doneTextButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
     [_doneTextButton sizeToFit];
     [self addSubview:_doneTextButton];
@@ -407,6 +411,11 @@
 #pragma mark - Image Generation -
 + (UIImage *)doneImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"checkmark"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *doneImage = nil;
     
     UIGraphicsBeginImageContextWithOptions((CGSize){17,14}, NO, 0.0f);
@@ -430,6 +439,11 @@
 
 + (UIImage *)cancelImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"xmark"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *cancelImage = nil;
     
     UIGraphicsBeginImageContextWithOptions((CGSize){16,16}, NO, 0.0f);
@@ -459,6 +473,11 @@
 
 + (UIImage *)rotateCCWImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"rotate.left.fill"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *rotateImage = nil;
     
     UIGraphicsBeginImageContextWithOptions((CGSize){18,21}, NO, 0.0f);
@@ -496,6 +515,11 @@
 
 + (UIImage *)rotateCWImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"rotate.right.fill"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *rotateCCWImage = [self.class rotateCCWImage];
     UIGraphicsBeginImageContextWithOptions(rotateCCWImage.size, NO, rotateCCWImage.scale);
     CGContextRef context = UIGraphicsGetCurrentContext();
@@ -509,6 +533,11 @@
 
 + (UIImage *)resetImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"arrow.counterclockwise"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *resetImage = nil;
     
     UIGraphicsBeginImageContextWithOptions((CGSize){22,18}, NO, 0.0f);
@@ -553,6 +582,11 @@
 
 + (UIImage *)clampImage
 {
+    if (@available(iOS 13.0, *)) {
+        return [UIImage systemImageNamed:@"aspectratio.fill"
+                       withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
+    }
+
     UIImage *clampImage = nil;
     
     UIGraphicsBeginImageContextWithOptions((CGSize){22,16}, NO, 0.0f);


### PR DESCRIPTION
In more recent versions of iOS, the design language of the icons has gone from square, single point line artwork to more bold, curved iconography.

In order to make this library look more consistent with the system on iOS 13 and above, this PR swaps out my original icons for the equivalents in SFSymobls. :)

![Simulator Screen Shot - iPod touch (7th generation) - 2020-12-15 at 23 21 06](https://user-images.githubusercontent.com/429119/102235165-02eb8600-3f2d-11eb-8bbc-61080fe9105b.png)
