### PR TITLE
Refined Generating Rotated Crop Images

### DIFF
--- a/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.h
+++ b/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.h
@@ -25,7 +25,15 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface UIImage (TOCropRotate)
-- (nonnull UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular;
+
+/// Crops a portion of an existing image object and returns it as a new image
+/// @param frame The region inside the image (In image pixel space) to crop
+/// @param angle If any, the angle the image is rotated at as well
+/// @param circular Whether the resulting image is returned as a square or a circle
+- (nonnull UIImage *)croppedImageWithFrame:(CGRect)frame
+                                     angle:(NSInteger)angle
+                              circularClip:(BOOL)circular;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I can't remember why I originally wrote the rotation cropping logic the way I did. I think at the beginning I had a legitimate reason for thinking it saved memory (But there's no evidence of that), and since then I simply didn't want to spend the time researching the necessary Core Graphics code to perform the rotation.

Thanks to PaintCode, I was able to work out the flow of what steps I needed to do this, and it ended up being far less code than I thought. Job done. :D