### PR TITLE
Cleaned up done and cancel button color

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -185,7 +185,7 @@
  Color for the 'Done' button.
  Setting this will override the default color.
  */
-@property (nullable, nonatomic, copy) UIColor *doneButtonColor;
+@property (null_resettable, nonatomic, copy) UIColor *doneButtonColor;
 
 /**
  Color for the 'Cancel' button.

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.h
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UIButton *doneTextButton;
 @property (nonatomic, strong, readonly) UIButton *doneIconButton;
 @property (nonatomic, copy) NSString *doneTextButtonTitle;
-@property (nonatomic, copy) UIColor *doneButtonColor;
+@property (null_resettable, nonatomic, copy) UIColor *doneButtonColor;
 
 /* The 'Cancel' buttons to cancel the crop. The text button is displayed
  in portrait mode and the icon one, in landscape. */
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UIButton *cancelIconButton;
 @property (nonatomic, readonly) UIView *visibleCancelButton;
 @property (nonatomic, copy) NSString *cancelTextButtonTitle;
-@property (nonatomic, copy) UIColor *cancelButtonColor;
+@property (null_resettable, nonatomic, copy) UIColor *cancelButtonColor;
 
 @property (nonatomic, assign) BOOL showOnlyIcons;
 

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.h
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UIButton *cancelIconButton;
 @property (nonatomic, readonly) UIView *visibleCancelButton;
 @property (nonatomic, copy) NSString *cancelTextButtonTitle;
-@property (null_resettable, nonatomic, copy) UIColor *cancelButtonColor;
+@property (nullable, nonatomic, copy) UIColor *cancelButtonColor;
 
 @property (nonatomic, assign) BOOL showOnlyIcons;
 

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -92,7 +92,10 @@
     [_doneIconButton setTintColor:[UIColor colorWithRed:1.0f green:0.8f blue:0.0f alpha:1.0f]];
     [_doneIconButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
     [self addSubview:_doneIconButton];
-    
+
+    // Set the default color for the done buttons
+    self.doneButtonColor = nil;
+
     _cancelTextButton = [UIButton buttonWithType:UIButtonTypeSystem];
     
     [_cancelTextButton setTitle: _cancelTextButtonTitle ?
@@ -423,6 +426,8 @@
 }
 
 - (void)setCancelButtonColor:(UIColor *)cancelButtonColor {
+    // Default color is app tint color
+    if (cancelButtonColor == _cancelButtonColor) { return; }
     _cancelButtonColor = cancelButtonColor;
     [_cancelTextButton setTitleColor:_cancelButtonColor forState:UIControlStateNormal];
     [_cancelIconButton setTintColor:_cancelButtonColor];
@@ -430,6 +435,13 @@
 }
 
 - (void)setDoneButtonColor:(UIColor *)doneButtonColor {
+    // Set the default color when nil is specified
+    if (doneButtonColor == nil) {
+        doneButtonColor = [UIColor colorWithRed:1.0f green:0.8f blue:0.0f alpha:1.0f];
+    }
+
+    if (doneButtonColor == _doneButtonColor) { return; }
+
     _doneButtonColor = doneButtonColor;
     [_doneTextButton setTitleColor:_doneButtonColor forState:UIControlStateNormal];
     [_doneIconButton setTintColor:_doneButtonColor];

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -65,6 +65,10 @@
     // Uncomment this if you do not want translucency effect
     //cropController.cropView.translucencyAlwaysHidden = YES;
 
+    // Set toolbar action button colors
+    // cropController.doneButtonColor = [UIColor redColor];
+    // cropController.cancelButtonColor = [UIColor greenColor];
+
     self.image = image;
     
     //If profile picture, push onto the same navigation stack

--- a/Swift/CropViewController/CropViewController.h
+++ b/Swift/CropViewController/CropViewController.h
@@ -1,7 +1,7 @@
 //
 //  CropViewController.h
 //
-//  Copyright 2017-2018 Timothy Oliver. All rights reserved.
+//  Copyright 2017-2020 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -1,7 +1,7 @@
 //
 //  CropViewController.swift
 //
-//  Copyright 2017-2018 Timothy Oliver. All rights reserved.
+//  Copyright 2017-2020 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to
@@ -422,7 +422,7 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     Color for the 'Done' button.
     Setting this will override the default color.
     */
-    public var doneButtonColor: UIColor! {
+    public var doneButtonColor: UIColor? {
         set { toCropViewController.doneButtonColor = newValue }
         get { return toCropViewController.doneButtonColor }
     }
@@ -431,7 +431,7 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     Color for the 'Cancel' button.
     Setting this will override the default color.
     */
-    public var cancelButtonColor: UIColor! {
+    public var cancelButtonColor: UIColor? {
         set { toCropViewController.cancelButtonColor = newValue }
         get { return toCropViewController.cancelButtonColor }
     }

--- a/Swift/CropViewControllerExample/ViewController.swift
+++ b/Swift/CropViewControllerExample/ViewController.swift
@@ -51,6 +51,10 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
         //cropController.toolbar.cancelButtonHidden = true
         //cropController.toolbar.clampButtonHidden = true
 
+        // Set toolbar action button colors
+        // cropController.doneButtonColor = UIColor.red
+        // cropController.cancelButtonColor = UIColor.green
+
         self.image = image
         
         //If profile picture, push onto the same navigation stack


### PR DESCRIPTION
Cleans up #458 by marking the colors as properly nullable variants in Objective-C and making the properties optional.