### PR TITLE
Added accessibility label to Reset button

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -141,6 +141,10 @@
     _resetButton.enabled = NO;
     [_resetButton setImage:[TOCropToolbar resetImage] forState:UIControlStateNormal];
     [_resetButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
+    _resetButton.accessibilityLabel = NSLocalizedStringFromTableInBundle(@"Reset",
+                                                                         @"TOCropViewControllerLocalizable",
+                                                                         resourceBundle,
+                                                                         nil);
     [self addSubview:_resetButton];
 }
 


### PR DESCRIPTION
iOS VoiceOver is reading the reset button as something like 'Arrow, counter-clockwise' and we would like it to use the work Reset instead. This word appears to be something that is available in the Localizable strings file, so I have pulled it from there and assigned it to the accessibility label of the reset button.