### PR TITLE
Prevent double tapping the done button

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -954,6 +954,8 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         };
 
         return;
+    } else {
+      self.toolbar.doneTextButton.enabled = false;
     }
     
     BOOL isCallbackOrDelegateHandled = NO;


### PR DESCRIPTION
fixes an issue where tapping the done button multiple times (common on slower devices) would trigger multiple callbacks