### PR TITLE
Prevent from steadily zooming in when cycling between alternate aspectRatios and original

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropView.m
+++ b/Objective-C/TOCropViewController/Views/TOCropView.m
@@ -1403,9 +1403,12 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
         return;
     }
     
+    BOOL zoomOut = NO;
+
     // Passing in an empty size will revert back to the image aspect ratio
     if (aspectRatio.width < FLT_EPSILON && aspectRatio.height < FLT_EPSILON) {
         aspectRatio = (CGSize){self.imageSize.width, self.imageSize.height};
+        zoomOut = YES; // Prevent from steadily zooming in when cycling between alternate aspectRatios and original
     }
 
     CGRect boundsFrame = self.contentBounds;
@@ -1418,7 +1421,6 @@ typedef NS_ENUM(NSInteger, TOCropViewOverlayEdge) {
     else
         cropBoxIsPortrait = aspectRatio.width < aspectRatio.height;
 
-    BOOL zoomOut = NO;
     if (cropBoxIsPortrait) {
         CGFloat newWidth = floorf(cropBoxFrame.size.height * (aspectRatio.width/aspectRatio.height));
         CGFloat delta = cropBoxFrame.size.width - newWidth;


### PR DESCRIPTION
Hi Tim, it's Josh from the Tokyo iOS Meetup. This doesn't keep the zoom level, but I think it makes sense to reset it when going back to the default one at least. Tell me what you think/if you disagree!

Issue below related
- https://github.com/TimOliver/TOCropViewController/issues/354

### Before / After

https://user-images.githubusercontent.com/25879490/185714984-95002881-956a-41bf-a470-1a88501586c2.mp4



https://user-images.githubusercontent.com/25879490/185714935-0887fb2b-fac7-42d8-b249-f8f8271524d1.mp4




