### PR TITLE
Use a preferred property in iOS 11.0

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1295,6 +1295,9 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         if (self.statusBarHidden) {
             statusBarHeight = 0.0f;
         }
+        else if (@available(iOS 11.0, *)) {
+            statusBarHeight = self.view.safeAreaInsets.top;
+        }
         else {
             statusBarHeight = self.topLayoutGuide.length;
         }


### PR DESCRIPTION
Hi,

This PR changes to use the `safeAreaInsets` property of `UIView` in iOS 11.0 to resolve the following compiler warning:

```
'topLayoutGuide' is deprecated: first deprecated in iOS 11.0 - Use view.safeAreaLayoutGuide.topAnchor instead of topLayoutGuide.bottomAnchor
```

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621367-toplayoutguide