### PR TITLE
Use the recommended way to detect the current user device

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1278,7 +1278,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         // We do need to include the status bar height on devices
         // that have a physical hardware inset, like an iPhone X notch
         BOOL hardwareRelatedInset = self.view.safeAreaInsets.bottom > FLT_EPSILON
-                                    && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone;
+                                    && UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
 
         // Always have insetting on Mac Catalyst
         #if TARGET_OS_MACCATALYST


### PR DESCRIPTION
Hi,

This PR changes to use the `userInterfaceIdiom` property of `UIDevice` directly to resolve the following warning:

```
'UI_USER_INTERFACE_IDIOM' is deprecated: first deprecated in iOS 13.0 - Use -[UIDevice userInterfaceIdiom] directly.
```