### PR TITLE
make `reverseContentLayout` externally modifiable

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -285,6 +285,14 @@
  */
 @property (nonatomic, assign) BOOL cancelButtonHidden;
 
+/**
+ When enabled, the toolbar is displayed in RTL layout.
+
+ Default is NO.
+ */
+@property (nonatomic, assign) BOOL reverseContentLayout
+;
+
 /** 
  If `showActivitySheetOnDone` is true, then these activity items will 
  be supplied to that UIActivityViewController in addition to the 

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -1186,6 +1186,16 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self.toolbar.cancelButtonHidden;
 }
 
+- (BOOL)reverseContentLayout
+{
+    return self.toolbar.reverseContentLayout;
+}
+- (void)setReverseContentLayout:(BOOL)reverseContentLayout
+{
+
+    self.toolbar.reverseContentLayout = reverseContentLayout;
+}
+
 - (void)setResetAspectRatioEnabled:(BOOL)resetAspectRatioEnabled
 {
     self.cropView.resetAspectRatioEnabled = resetAspectRatioEnabled;

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.h
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.h
@@ -78,6 +78,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL doneButtonHidden;
 @property (nonatomic, assign) BOOL cancelButtonHidden;
 
+/* For languages like Arabic where they natively present content flipped from English */
+@property (nonatomic, assign) BOOL reverseContentLayout;
+
 /* Enable the reset button */
 @property (nonatomic, assign) BOOL resetButtonEnabled;
 

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -39,8 +39,6 @@
 
 @property (nonatomic, strong) UIButton *rotateButton; // defaults to counterclockwise button for legacy compatibility
 
-@property (nonatomic, assign) BOOL reverseContentLayout; // For languages like Arabic where they natively present content flipped from English
-
 @end
 
 @implementation TOCropToolbar
@@ -61,10 +59,10 @@
     
     // On iOS 9, we can use the new layout features to determine whether we're in an 'Arabic' style language mode
     if (@available(iOS 9.0, *)) {
-        self.reverseContentLayout = ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft);
+        _reverseContentLayout = ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft);
     }
     else {
-        self.reverseContentLayout = [[[NSLocale preferredLanguages] objectAtIndex:0] hasPrefix:@"ar"];
+        _reverseContentLayout = [[[NSLocale preferredLanguages] objectAtIndex:0] hasPrefix:@"ar"];
     }
     
     // Get the resource bundle depending on the framework/dependency manager we're using
@@ -341,6 +339,14 @@
 - (CGRect)clampButtonFrame
 {
     return self.clampButton.frame;
+}
+
+- (void)setReverseContentLayout:(BOOL)reverseContentLayout {
+    if (_reverseContentLayout == reverseContentLayout)
+        return;
+
+    _reverseContentLayout = reverseContentLayout;
+    [self setNeedsLayout];
 }
 
 - (void)setClampButtonHidden:(BOOL)clampButtonHidden {

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -52,7 +52,9 @@
 
     //cropController.rotateButtonsHidden = YES;
     //cropController.rotateClockwiseButtonHidden = NO;
-    
+
+    //cropController.reverseContentLayout = YES;
+
     //cropController.doneButtonTitle = @"Title";
     //cropController.cancelButtonTitle = @"Title";
 

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -435,7 +435,18 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
         set { toCropViewController.cancelButtonColor = newValue }
         get { return toCropViewController.cancelButtonColor }
     }
-    
+
+    /**
+    A computed property to get or set the reverse layout on toolbar.
+    By setting this property, you can control the direction in which the toolbar is laid out.
+
+    Default is NO.
+    */
+    public var reverseContentLayout: Bool {
+        set { toCropViewController.reverseContentLayout = newValue }
+        get { toCropViewController.reverseContentLayout }
+    }
+
     /**
      This class internally manages and abstracts access to a `TOCropViewController` instance
      :nodoc:

--- a/Swift/CropViewControllerExample/ViewController.swift
+++ b/Swift/CropViewControllerExample/ViewController.swift
@@ -55,6 +55,9 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
         // cropController.doneButtonColor = UIColor.red
         // cropController.cancelButtonColor = UIColor.green
 
+        // Change toolbar layout direction
+        // cropController.toolbar.reverseContentLayout = true
+
         self.image = image
         
         //If profile picture, push onto the same navigation stack


### PR DESCRIPTION
## Why
The `reverseContentLayout` is currently determined by the `TOCropToolBar`'s `semanticContentAttributes` and is used when determining whether the view should be reversed left or right.

https://github.com/TimOliver/TOCropViewController/blob/a942414508012b13102f776eb65dac655f31cabb/Objective-C/TOCropViewController/Views/TOCropToolbar.m#L64

However, this is determined at setup time and cannot be changed later.
This makes it difficult to determine the layout direction externally.

## How
Expose `reverseContentLayout` and allow it to be changed externally.
In addition, call `setNeedsLayout` in the setter to change the layout according to the changed value.

## ScreenShot

### CropViewControllerExample

| reverseContentLayout is false | reverseContentLayout is true |
| :---: | :---: |
| <img src="https://github.com/TimOliver/TOCropViewController/assets/44093643/4cfaf3d5-032f-444c-87ee-8c0c69d3e7da" width="250"/> | <img src="https://github.com/TimOliver/TOCropViewController/assets/44093643/c52bbe84-f84b-43be-a2e6-811ad718c56b" width="250"/> |

### TOCropViewControllerExample

| reverseContentLayout is false | reverseContentLayout is true |
| :---: | :---: |
| <img src="https://github.com/TimOliver/TOCropViewController/assets/44093643/82a9cd25-4256-4c8d-bbba-3c01b9bb3a6d" width="250"/> | <img src="https://github.com/TimOliver/TOCropViewController/assets/44093643/dbbc5d09-f28c-4cbb-a89e-c299281f492a" width="250"/> |


