### PR TITLE
Remove 16x6 aspect ratio

### DIFF
--- a/Objective-C/TOCropViewController/Constants/TOCropViewConstants.h
+++ b/Objective-C/TOCropViewController/Constants/TOCropViewConstants.h
@@ -43,7 +43,6 @@ typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatioPreset) {
     TOCropViewControllerAspectRatioPreset5x4,
     TOCropViewControllerAspectRatioPreset7x5,
     TOCropViewControllerAspectRatioPreset16x9,
-    TOCropViewControllerAspectRatioPreset16x6,
     TOCropViewControllerAspectRatioPresetCustom
 };
 

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -671,9 +671,6 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         case TOCropViewControllerAspectRatioPreset16x9:
             aspectRatio = CGSizeMake(16.0f, 9.0f);
             break;
-        case TOCropViewControllerAspectRatioPreset16x6:
-            aspectRatio = CGSizeMake(16.0f, 6.0f);
-            break;
         case TOCropViewControllerAspectRatioPresetCustom:
             aspectRatio = self.customAspectRatio;
             break;


### PR DESCRIPTION
I merged a PR to add 16x6 to the aspect ratio list, but discovered it hadn't updated the UI to match, and was causing a crash as a result.

Looking back, let's just keep the official list of ratios to the standardised ones.