### PR TITLE
Fix privacy manifest missing key 'NSPrivacyCollectedDataType'

### DIFF
--- a/Objective-C/TOCropViewController/Resources/PrivacyInfo.xcprivacy
+++ b/Objective-C/TOCropViewController/Resources/PrivacyInfo.xcprivacy
@@ -7,9 +7,7 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict/>


### PR DESCRIPTION
This will allow Privacy Report to be generated without any errors about missing keys