### PR TITLE
Remove deprecated Core Graphics renderer APIs

### DIFF
--- a/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
@@ -33,10 +33,13 @@
 
 - (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
 {
-    UIImage *croppedImage = nil;
-    UIGraphicsBeginImageContextWithOptions(frame.size, !self.hasAlpha && !circular, self.scale);
-    {
-        CGContextRef context = UIGraphicsGetCurrentContext();
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat new];
+    format.opaque = !self.hasAlpha && !circular;
+    format.scale = self.scale;
+
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:frame.size format:format];
+    UIImage *croppedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
+        CGContextRef context = rendererContext.CGContext;
 
         // If we're capturing a circular image, set the clip mask first
         if (circular) {
@@ -68,10 +71,7 @@
         // We do not need to worry about specifying the size here since we're already
         // constrained by the context image size
         [self drawAtPoint:CGPointZero];
-        
-        croppedImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
+    }];
 
     // Re-apply the retina scale we originally had
     return [UIImage imageWithCGImage:croppedImage.CGImage scale:self.scale orientation:UIImageOrientationUp];

--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -466,11 +466,8 @@
                        withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
     }
 
-    UIImage *doneImage = nil;
-    
-    UIGraphicsBeginImageContextWithOptions((CGSize){17,14}, NO, 0.0f);
-    {
-        //// Rectangle Drawing
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:(CGSize){17,14}];
+    UIImage *doneImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         UIBezierPath* rectanglePath = UIBezierPath.bezierPath;
         [rectanglePath moveToPoint: CGPointMake(1, 7)];
         [rectanglePath addLineToPoint: CGPointMake(6, 12)];
@@ -478,11 +475,7 @@
         [UIColor.whiteColor setStroke];
         rectanglePath.lineWidth = 2;
         [rectanglePath stroke];
-        
-        
-        doneImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
+    }];
     
     return doneImage;
 }
@@ -494,29 +487,22 @@
                        withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]];
     }
 
-    UIImage *cancelImage = nil;
-    
-    UIGraphicsBeginImageContextWithOptions((CGSize){16,16}, NO, 0.0f);
-    {
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:(CGSize){16,16}];
+    UIImage *cancelImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         UIBezierPath* bezierPath = UIBezierPath.bezierPath;
         [bezierPath moveToPoint: CGPointMake(15, 15)];
         [bezierPath addLineToPoint: CGPointMake(1, 1)];
         [UIColor.whiteColor setStroke];
         bezierPath.lineWidth = 2;
         [bezierPath stroke];
-        
-        
-        //// Bezier 2 Drawing
+
         UIBezierPath* bezier2Path = UIBezierPath.bezierPath;
         [bezier2Path moveToPoint: CGPointMake(1, 15)];
         [bezier2Path addLineToPoint: CGPointMake(15, 1)];
         [UIColor.whiteColor setStroke];
         bezier2Path.lineWidth = 2;
         [bezier2Path stroke];
-        
-        cancelImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
+    }];
     
     return cancelImage;
 }
@@ -529,17 +515,12 @@
                 imageWithBaselineOffsetFromBottom:4];
     }
 
-    UIImage *rotateImage = nil;
-    
-    UIGraphicsBeginImageContextWithOptions((CGSize){18,21}, NO, 0.0f);
-    {
-        //// Rectangle 2 Drawing
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:(CGSize){18,21}];
+    UIImage *rotateImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         UIBezierPath* rectangle2Path = [UIBezierPath bezierPathWithRect: CGRectMake(0, 9, 12, 12)];
         [UIColor.whiteColor setFill];
         [rectangle2Path fill];
-        
-        
-        //// Rectangle 3 Drawing
+
         UIBezierPath* rectangle3Path = UIBezierPath.bezierPath;
         [rectangle3Path moveToPoint: CGPointMake(5, 3)];
         [rectangle3Path addLineToPoint: CGPointMake(10, 6)];
@@ -548,19 +529,15 @@
         [rectangle3Path closePath];
         [UIColor.whiteColor setFill];
         [rectangle3Path fill];
-        
-        
-        //// Bezier Drawing
+
         UIBezierPath* bezierPath = UIBezierPath.bezierPath;
         [bezierPath moveToPoint: CGPointMake(10, 3)];
         [bezierPath addCurveToPoint: CGPointMake(17.5, 11) controlPoint1: CGPointMake(15, 3) controlPoint2: CGPointMake(17.5, 5.91)];
         [UIColor.whiteColor setStroke];
         bezierPath.lineWidth = 1;
         [bezierPath stroke];
-        rotateImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
-    
+    }];
+
     return rotateImage;
 }
 
@@ -573,13 +550,14 @@
     }
 
     UIImage *rotateCCWImage = [self.class rotateCCWImage];
-    UIGraphicsBeginImageContextWithOptions(rotateCCWImage.size, NO, rotateCCWImage.scale);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextTranslateCTM(context, rotateCCWImage.size.width, rotateCCWImage.size.height);
-    CGContextRotateCTM(context, M_PI);
-    CGContextDrawImage(context,CGRectMake(0,0,rotateCCWImage.size.width,rotateCCWImage.size.height),rotateCCWImage.CGImage);
-    UIImage *rotateCWImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotateCCWImage.size];
+    UIImage *rotateCWImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
+        CGContextRef context = rendererContext.CGContext;
+        CGContextTranslateCTM(context, rotateCCWImage.size.width, rotateCCWImage.size.height);
+        CGContextRotateCTM(context, M_PI);
+        CGContextDrawImage(context,CGRectMake(0,0,rotateCCWImage.size.width,rotateCCWImage.size.height),rotateCCWImage.CGImage);
+    }];
+
     return rotateCWImage;
 }
 
@@ -591,12 +569,8 @@
                 imageWithBaselineOffsetFromBottom:0];;
     }
 
-    UIImage *resetImage = nil;
-    
-    UIGraphicsBeginImageContextWithOptions((CGSize){22,18}, NO, 0.0f);
-    {
-        
-        //// Bezier 2 Drawing
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:(CGSize){22,18}];
+    UIImage *resetImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         UIBezierPath* bezier2Path = UIBezierPath.bezierPath;
         [bezier2Path moveToPoint: CGPointMake(22, 9)];
         [bezier2Path addCurveToPoint: CGPointMake(13, 18) controlPoint1: CGPointMake(22, 13.97) controlPoint2: CGPointMake(17.97, 18)];
@@ -613,9 +587,7 @@
         [bezier2Path closePath];
         [UIColor.whiteColor setFill];
         [bezier2Path fill];
-        
-        
-        //// Polygon Drawing
+
         UIBezierPath* polygonPath = UIBezierPath.bezierPath;
         [polygonPath moveToPoint: CGPointMake(5, 15)];
         [polygonPath addLineToPoint: CGPointMake(10, 9)];
@@ -624,11 +596,7 @@
         [polygonPath closePath];
         [UIColor.whiteColor setFill];
         [polygonPath fill];
-
-
-        resetImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
+    }];
     
     return resetImage;
 }
@@ -640,46 +608,38 @@
                        withConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightSemibold]]
                 imageWithBaselineOffsetFromBottom:0];
     }
-
-    UIImage *clampImage = nil;
     
-    UIGraphicsBeginImageContextWithOptions((CGSize){22,16}, NO, 0.0f);
-    {
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:(CGSize){22,16}];
+    UIImage *clampImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
         //// Color Declarations
         UIColor* outerBox = [UIColor colorWithRed: 1 green: 1 blue: 1 alpha: 0.553];
         UIColor* innerBox = [UIColor colorWithRed: 1 green: 1 blue: 1 alpha: 0.773];
-        
+
         //// Rectangle Drawing
         UIBezierPath* rectanglePath = [UIBezierPath bezierPathWithRect: CGRectMake(0, 3, 13, 13)];
         [UIColor.whiteColor setFill];
         [rectanglePath fill];
-        
-        
+
         //// Outer
         {
             //// Top Drawing
             UIBezierPath* topPath = [UIBezierPath bezierPathWithRect: CGRectMake(0, 0, 22, 2)];
             [outerBox setFill];
             [topPath fill];
-            
-            
+
+
             //// Side Drawing
             UIBezierPath* sidePath = [UIBezierPath bezierPathWithRect: CGRectMake(19, 2, 3, 14)];
             [outerBox setFill];
             [sidePath fill];
         }
-        
-        
+
         //// Rectangle 2 Drawing
         UIBezierPath* rectangle2Path = [UIBezierPath bezierPathWithRect: CGRectMake(14, 3, 4, 13)];
         [innerBox setFill];
         [rectangle2Path fill];
-        
-        
-        clampImage = UIGraphicsGetImageFromCurrentImageContext();
-    }
-    UIGraphicsEndImageContext();
-    
+    }];
+
     return clampImage;
 }
 


### PR DESCRIPTION
Fixes #577. Replaces all cases of `UIGraphicsBeginImageContextWithOptions` with `UIGraphicsImageRenderer`.