### PR TITLE
Improve test image creation

### DIFF
--- a/Objective-C/TOCropViewControllerTests/TOCropViewControllerTests.m
+++ b/Objective-C/TOCropViewControllerTests/TOCropViewControllerTests.m
@@ -19,11 +19,11 @@
 
 - (void)testViewControllerInstance {
     //Create a basic image
-    UIGraphicsBeginImageContextWithOptions((CGSize){10, 10}, NO, 1.0f);
-    CGContextFillRect(UIGraphicsGetCurrentContext(), (CGRect){0,0,10,10});
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(10, 10)];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+        [context fillRect:CGRectMake(0, 0, 10, 10)];
+    }];
+
     //Perform test
     TOCropViewController *controller = [[TOCropViewController alloc] initWithImage:image];
     UIView *view = controller.view;


### PR DESCRIPTION
Old image creation methods have been deprecated, so this PR replaces them with new APIs.
https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho
https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer