### PR TITLE
Update PrivacyInfo.xcprivacy for ITMS-91108: Invalid privacy manifest issue

### DIFF
--- a/Objective-C/TOCropViewController/Resources/PrivacyInfo.xcprivacy
+++ b/Objective-C/TOCropViewController/Resources/PrivacyInfo.xcprivacy
@@ -9,6 +9,23 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryPhotoLibrary</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>Image cropping functionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryCamera</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>Image capturing for cropping</string>
+			</array>
+		</dict>
+    	</array>
 </dict>
 </plist>


### PR DESCRIPTION
I received an email with the following content from apple.

```
ITMS-91108: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: “TOCropViewControllerBundle.bundle/PrivacyInfo.xcprivacy”. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Keys and values in any privacy manifest must be in a valid format. For more details about privacy manifest files, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk.
```

Please let me know if what I added fits your policy. If not, please update with your fixes by November 12, 2024.
Thank you.

https://github.com/TimOliver/TOCropViewController/issues/592