### PR TITLE
Move TOCropViewControllerAspectRatioPreset to a class and make it configurable

### DIFF
--- a/Objective-C/TOCropViewController/Constants/TOCropViewConstants.h
+++ b/Objective-C/TOCropViewController/Constants/TOCropViewConstants.h
@@ -31,22 +31,6 @@ typedef NS_ENUM(NSInteger, TOCropViewCroppingStyle) {
 };
 
 /**
- Preset values of the most common aspect ratios that can be used to quickly configure
- the crop view controller.
- */
-typedef NS_ENUM(NSInteger, TOCropViewControllerAspectRatioPreset) {
-    TOCropViewControllerAspectRatioPresetOriginal,
-    TOCropViewControllerAspectRatioPresetSquare,
-    TOCropViewControllerAspectRatioPreset3x2,
-    TOCropViewControllerAspectRatioPreset5x3,
-    TOCropViewControllerAspectRatioPreset4x3,
-    TOCropViewControllerAspectRatioPreset5x4,
-    TOCropViewControllerAspectRatioPreset7x5,
-    TOCropViewControllerAspectRatioPreset16x9,
-    TOCropViewControllerAspectRatioPresetCustom
-};
-
-/**
  Whether the control toolbar is placed at the bottom or the top
  */
 typedef NS_ENUM(NSInteger, TOCropViewControllerToolbarPosition) {

--- a/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.h
+++ b/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.h
@@ -1,7 +1,7 @@
 //
-//  CropViewController.h
+//  TOCropViewControllerAspectRatioPreset.h
 //
-//  Copyright 2017-2024 Timothy Oliver. All rights reserved.
+//  Copyright 2015-2024 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to
@@ -20,15 +20,21 @@
 //  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "TOCropViewController.h"
-#import "TOCropView.h"
-#import "TOCropToolbar.h"
-#import "TOCropViewConstants.h"
-#import "TOCropViewControllerAspectRatioPreset.h"
-#import "UIImage+CropRotate.h"
+NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT double CropViewControllerVersionNumber;
-FOUNDATION_EXPORT const unsigned char CropViewControllerVersionString[];
+@interface TOCropViewControllerAspectRatioPreset : NSObject
 
+@property (nonatomic, readonly) CGSize size;
+@property (nonatomic, readonly) NSString *title;
+
++ (NSArray<TOCropViewControllerAspectRatioPreset *> *)portraitPresets;
++ (NSArray<TOCropViewControllerAspectRatioPreset *> *)landscapePresets;
+
+- (nonnull instancetype)initWithSize:(CGSize)size title:(NSString *)title;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.m
+++ b/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.m
@@ -1,0 +1,94 @@
+//
+//  TOCropViewControllerAspectRatioPreset.m
+//
+//  Copyright 2015-2024 Timothy Oliver. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TOCropViewControllerAspectRatioPreset.h"
+#if !__has_include(<TOCropViewController/TOCropViewConstants.h>)
+#import "TOCropViewConstants.h"
+#else
+#import <TOCropViewController/TOCropViewConstants.h>
+#endif
+
+@interface TOCropViewControllerAspectRatioPreset ()
+
+@property (nonatomic, assign, readwrite) CGFloat width;
+@property (nonatomic, assign, readwrite) CGFloat height;
+@property (nonatomic, strong, readwrite) NSString *title;
+
+@end
+
+@implementation TOCropViewControllerAspectRatioPreset
+
+- (instancetype)initWithSize:(CGSize)size title:(NSString *)title
+{
+    self = [super init];
+    if (self) {
+        _size = size;
+        _title = title;
+    }
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+    if (![object isKindOfClass:[TOCropViewControllerAspectRatioPreset class]]) {
+        return NO;
+    }
+    TOCropViewControllerAspectRatioPreset *other = (TOCropViewControllerAspectRatioPreset *)object;
+    return CGSizeEqualToSize(self.size, other.size) && [self.title isEqualToString:other.title];
+}
+
++ (NSArray<TOCropViewControllerAspectRatioPreset *> *)portraitPresets
+{
+    TOCropViewControllerAspectRatioPreset *object = [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeZero title:@"Original"];
+	NSBundle *resourceBundle = TO_CROP_VIEW_RESOURCE_BUNDLE_FOR_OBJECT(object);
+    return @[
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeZero title:NSLocalizedStringFromTableInBundle(@"Original", @"TOCropViewControllerLocalizable", resourceBundle, nil)],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(1.0f, 1.0f) title:NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil)],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(2.0f, 3.0f) title:@"2:3"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(3.0f, 5.0f) title:@"3:5"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(3.0f, 4.0f) title:@"3:4"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(4.0f, 5.0f) title:@"4:5"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(5.0f, 7.0f) title:@"5:7"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(9.0f, 16.0f) title:@"9:16"],
+    ];
+}
+
++ (NSArray<TOCropViewControllerAspectRatioPreset *> *)landscapePresets
+{
+    TOCropViewControllerAspectRatioPreset *object = [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeZero title:@"Original"];
+	NSBundle *resourceBundle = TO_CROP_VIEW_RESOURCE_BUNDLE_FOR_OBJECT(object);
+    return @[
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeZero title:NSLocalizedStringFromTableInBundle(@"Original", @"TOCropViewControllerLocalizable", resourceBundle, nil)],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(1.0f, 1.0f) title:NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil)],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(3.0f, 2.0f) title:@"3:2"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(5.0f, 3.0f) title:@"5:3"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(4.0f, 3.0f) title:@"4:3"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(5.0f, 4.0f) title:@"5:4"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(7.0f, 5.0f) title:@"7:5"],
+        [[TOCropViewControllerAspectRatioPreset alloc] initWithSize:CGSizeMake(16.0f, 9.0f) title:@"16:9"],
+    ];
+}
+@end
+
+

--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -24,10 +24,12 @@
 
 #if !__has_include(<TOCropViewController/TOCropViewConstants.h>)
 #import "TOCropViewConstants.h"
+#import "TOCropViewControllerAspectRatioPreset.h"
 #import "TOCropView.h"
 #import "TOCropToolbar.h"
 #else
 #import <TOCropViewController/TOCropViewConstants.h>
+#import <TOCropViewController/TOCropViewControllerAspectRatioPreset.h>
 #import <TOCropViewController/TOCropView.h>
 #import <TOCropViewController/TOCropToolbar.h>
 #endif
@@ -150,19 +152,7 @@
 /**
  A choice from one of the pre-defined aspect ratio presets
  */
-@property (nonatomic, assign) TOCropViewControllerAspectRatioPreset aspectRatioPreset;
-
-/**
- A CGSize value representing a custom aspect ratio, not listed in the presets.
- E.g. A ratio of 4:3 would be represented as (CGSize){4.0f, 3.0f}
- */
-@property (nonatomic, assign) CGSize customAspectRatio;
-
-/**
- If this is set alongside `customAspectRatio`, the custom aspect ratio
- will be shown as a selectable choice in the list of aspect ratios. (Default is `nil`)
- */
-@property (nullable, nonatomic, copy) NSString *customAspectRatioName;
+@property (nonatomic, assign) CGSize aspectRatioPreset;
 
 /**
  Title label which can be used to show instruction on the top of the crop view controller
@@ -324,7 +314,7 @@
  An array of `TOCropViewControllerAspectRatioPreset` enum values denoting which
  aspect ratios the crop view controller may display (Default is nil. All are shown)
  */
-@property (nullable, nonatomic, strong) NSArray<NSNumber *> *allowedAspectRatios;
+@property (nullable, nonatomic, strong) NSArray<TOCropViewControllerAspectRatioPreset *> *allowedAspectRatios;
 
 /**
  When the user hits cancel, or completes a
@@ -402,7 +392,7 @@
  @param aspectRatioPreset The aspect ratio preset
  @param animated Whether the transition to the aspect ratio is animated
  */
-- (void)setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)aspectRatioPreset animated:(BOOL)animated NS_SWIFT_NAME(setAspectRatioPreset(_:animated:));
+- (void)setAspectRatioPreset:(CGSize)aspectRatioPreset animated:(BOOL)animated NS_SWIFT_NAME(setAspectRatioPreset(_:animated:));
 
 /**
  Play a custom animation of the target image zooming to its position in

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -90,7 +90,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         _transitionController = [[TOCropViewControllerTransitioning alloc] init];
 
         // Default initial behaviour
-        _aspectRatioPreset = TOCropViewControllerAspectRatioPresetOriginal;
+        _aspectRatioPreset = CGSizeZero;
 
         #if TARGET_OS_MACCATALYST
         _toolbarPosition = TOCropViewControllerToolbarPositionTop;
@@ -170,7 +170,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 
     // If an initial aspect ratio was set before presentation, set it now once the rest of
     // the setup will have been done
-    if (self.aspectRatioPreset != TOCropViewControllerAspectRatioPresetOriginal) {
+    if (!CGSizeEqualToSize(self.aspectRatioPreset, CGSizeZero)) {
         [self setAspectRatioPreset:self.aspectRatioPreset animated:NO];
     }
 }
@@ -586,50 +586,28 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     
     //Prepare the localized options
 	NSString *cancelButtonTitle = NSLocalizedStringFromTableInBundle(@"Cancel", @"TOCropViewControllerLocalizable", resourceBundle, nil);
-	NSString *originalButtonTitle = NSLocalizedStringFromTableInBundle(@"Original", @"TOCropViewControllerLocalizable", resourceBundle, nil);
-	NSString *squareButtonTitle = NSLocalizedStringFromTableInBundle(@"Square", @"TOCropViewControllerLocalizable", resourceBundle, nil);
     
     //Prepare the list that will be fed to the alert view/controller
-    
-    // Ratio titles according to the order of enum TOCropViewControllerAspectRatioPreset
-    NSArray<NSString *> *portraitRatioTitles = @[originalButtonTitle, squareButtonTitle, @"2:3", @"3:5", @"3:4", @"4:5", @"5:7", @"9:16"];
-    NSArray<NSString *> *landscapeRatioTitles = @[originalButtonTitle, squareButtonTitle, @"3:2", @"5:3", @"4:3", @"5:4", @"7:5", @"16:9"];
 
-    NSMutableArray *ratioValues = [NSMutableArray array];
-    NSMutableArray *itemStrings = [NSMutableArray array];
+    NSArray<TOCropViewControllerAspectRatioPreset *> *presets;
 
     if (self.allowedAspectRatios == nil) {
-        for (NSInteger i = 0; i < TOCropViewControllerAspectRatioPresetCustom; i++) {
-            NSString *itemTitle = verticalCropBox ? portraitRatioTitles[i] : landscapeRatioTitles[i];
-            [itemStrings addObject:itemTitle];
-            [ratioValues addObject:@(i)];
-        }
+        presets = verticalCropBox ? [TOCropViewControllerAspectRatioPreset portraitPresets] : [TOCropViewControllerAspectRatioPreset landscapePresets];
     }
     else {
-        for (NSNumber *allowedRatio in self.allowedAspectRatios) {
-            TOCropViewControllerAspectRatioPreset ratio = allowedRatio.integerValue;
-            NSString *itemTitle = verticalCropBox ? portraitRatioTitles[ratio] : landscapeRatioTitles[ratio];
-            [itemStrings addObject:itemTitle];
-            [ratioValues addObject:allowedRatio];
-        }
-    }
-    
-    // If a custom aspect ratio is provided, and a custom name has been given to it, add it as a visible choice
-    if (self.customAspectRatioName.length > 0 && !CGSizeEqualToSize(CGSizeZero, self.customAspectRatio)) {
-        [itemStrings addObject:self.customAspectRatioName];
-        [ratioValues addObject:@(TOCropViewControllerAspectRatioPresetCustom)];
+        presets = self.allowedAspectRatios;
     }
 
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     [alertController addAction:[UIAlertAction actionWithTitle:cancelButtonTitle style:UIAlertActionStyleCancel handler:nil]];
 
     //Add each item to the alert controller
-    for (NSInteger i = 0; i < itemStrings.count; i++) {
+    for (NSInteger i = 0; i < presets.count; i++) {
         id handlerBlock = ^(UIAlertAction *action) {
-            [self setAspectRatioPreset:[ratioValues[i] integerValue] animated:YES];
+            [self setAspectRatioPreset:presets[i].size animated:YES];
             self.aspectRatioLockEnabled = YES;
         };
-        UIAlertAction *action = [UIAlertAction actionWithTitle:itemStrings[i] style:UIAlertActionStyleDefault handler:handlerBlock];
+        UIAlertAction *action = [UIAlertAction actionWithTitle:presets[i].title style:UIAlertActionStyleDefault handler:handlerBlock];
         [alertController addAction:action];
     }
 
@@ -640,58 +618,10 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
-- (void)setAspectRatioPreset:(TOCropViewControllerAspectRatioPreset)aspectRatioPreset animated:(BOOL)animated
+- (void)setAspectRatioPreset:(CGSize)aspectRatioPreset animated:(BOOL)animated
 {
-    CGSize aspectRatio = CGSizeZero;
-    
     _aspectRatioPreset = aspectRatioPreset;
-    
-    switch (aspectRatioPreset) {
-        case TOCropViewControllerAspectRatioPresetOriginal:
-            aspectRatio = CGSizeZero;
-            break;
-        case TOCropViewControllerAspectRatioPresetSquare:
-            aspectRatio = CGSizeMake(1.0f, 1.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset3x2:
-            aspectRatio = CGSizeMake(3.0f, 2.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset5x3:
-            aspectRatio = CGSizeMake(5.0f, 3.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset4x3:
-            aspectRatio = CGSizeMake(4.0f, 3.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset5x4:
-            aspectRatio = CGSizeMake(5.0f, 4.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset7x5:
-            aspectRatio = CGSizeMake(7.0f, 5.0f);
-            break;
-        case TOCropViewControllerAspectRatioPreset16x9:
-            aspectRatio = CGSizeMake(16.0f, 9.0f);
-            break;
-        case TOCropViewControllerAspectRatioPresetCustom:
-            aspectRatio = self.customAspectRatio;
-            break;
-    }
-    
-    // If the aspect ratio lock is not enabled, allow a swap
-    // If the aspect ratio lock is on, allow a aspect ratio swap
-    // only if the allowDimensionSwap option is specified.
-    BOOL aspectRatioCanSwapDimensions = !self.aspectRatioLockEnabled ||
-                                (self.aspectRatioLockEnabled && self.aspectRatioLockDimensionSwapEnabled);
-    
-    //If the image is a portrait shape, flip the aspect ratio to match
-    if (self.cropView.cropBoxAspectRatioIsPortrait &&
-        aspectRatioCanSwapDimensions)
-    {
-        CGFloat width = aspectRatio.width;
-        aspectRatio.width = aspectRatio.height;
-        aspectRatio.height = width;
-    }
-    
-    [self.cropView setAspectRatio:aspectRatio animated:animated];
+    [self.cropView setAspectRatio:aspectRatioPreset animated:animated];
 }
 
 - (void)rotateCropViewClockwise
@@ -1213,12 +1143,6 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     if (!self.aspectRatioPickerButtonHidden) {
         self.aspectRatioPickerButtonHidden = (resetAspectRatioEnabled == NO && self.aspectRatioLockEnabled);
     }
-}
-
-- (void)setCustomAspectRatio:(CGSize)customAspectRatio
-{
-    _customAspectRatio = customAspectRatio;
-    [self setAspectRatioPreset:TOCropViewControllerAspectRatioPresetCustom animated:NO];
 }
 
 - (BOOL)resetAspectRatioEnabled

--- a/Objective-C/TOCropViewController/include/TOCropViewControllerAspectRatioPreset.h
+++ b/Objective-C/TOCropViewController/include/TOCropViewControllerAspectRatioPreset.h
@@ -1,0 +1,1 @@
+../Models/TOCropViewControllerAspectRatioPreset.h

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -163,27 +163,9 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     /**
       A choice from one of the pre-defined aspect ratio presets
     */
-    public var aspectRatioPreset: CropViewControllerAspectRatioPreset {
+    public var aspectRatioPreset: CGSize {
         set { toCropViewController.aspectRatioPreset = newValue }
         get { return toCropViewController.aspectRatioPreset }
-    }
-    
-    /**
-     A CGSize value representing a custom aspect ratio, not listed in the presets.
-     E.g. A ratio of 4:3 would be represented as (CGSize){4.0f, 3.0f}
-     */
-    public var customAspectRatio: CGSize {
-        set { toCropViewController.customAspectRatio = newValue }
-        get { return toCropViewController.customAspectRatio }
-    }
-    
-    /**
-     If this is set alongside `customAspectRatio`, the custom aspect ratio
-     will be shown as a selectable choice in the list of aspect ratios. (Default is `nil`)
-     */
-    public var customAspectRatioName: String? {
-        set { toCropViewController.customAspectRatioName = newValue }
-        get { return toCropViewController.customAspectRatioName }
     }
     
     /**
@@ -334,8 +316,8 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
      aspect ratios the crop view controller may display (Default is nil. All are shown)
      */
     public var allowedAspectRatios: [CropViewControllerAspectRatioPreset]? {
-        set { toCropViewController.allowedAspectRatios = newValue?.map { NSNumber(value: $0.rawValue) } }
-        get { return toCropViewController.allowedAspectRatios?.compactMap { CropViewControllerAspectRatioPreset(rawValue: $0.intValue) } }
+        set { toCropViewController.allowedAspectRatios = newValue }
+        get { return toCropViewController.allowedAspectRatios }
     }
     
     /**
@@ -579,7 +561,7 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     @param aspectRatioPreset The aspect ratio preset
     @param animated Whether the transition to the aspect ratio is animated
     */
-    public func setAspectRatioPreset(_ aspectRatio: CropViewControllerAspectRatioPreset, animated: Bool) {
+    public func setAspectRatioPreset(_ aspectRatio: CGSize, animated: Bool) {
         toCropViewController.setAspectRatioPreset(aspectRatio, animated: animated)
     }
     

--- a/TOCropViewControllerExample.xcodeproj/project.pbxproj
+++ b/TOCropViewControllerExample.xcodeproj/project.pbxproj
@@ -98,6 +98,13 @@
 		2F5062F31F53E31F00AA9F14 /* TOCropViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 22DB4D831B234CFA008B8466 /* TOCropViewController.m */; };
 		2F5062F41F53E32800AA9F14 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 223424751ABBC0CD00BBC2B1 /* ViewController.m */; };
 		2F5062F51F53E32D00AA9F14 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 223424771ABBC0CD00BBC2B1 /* Main.storyboard */; };
+		39381CBE2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */ = {isa = PBXBuildFile; fileRef = 39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */; };
+		39381CBF2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */ = {isa = PBXBuildFile; fileRef = 39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */; };
+		39381CC02DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h in Headers */ = {isa = PBXBuildFile; fileRef = 39381CBC2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39381CC12DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */ = {isa = PBXBuildFile; fileRef = 39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */; };
+		39381CC22DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */ = {isa = PBXBuildFile; fileRef = 39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */; };
+		39381CC32DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h in Headers */ = {isa = PBXBuildFile; fileRef = 39381CBC2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		39381CC42DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */ = {isa = PBXBuildFile; fileRef = 39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */; };
 		FE3E0E3A21098448004DAE93 /* TOCropViewConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 220C8E9F21062DD300A9B25D /* TOCropViewConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
@@ -212,6 +219,8 @@
 		22F7331B259B71C400956847 /* TOCropViewControllerExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TOCropViewControllerExample.entitlements; sourceTree = "<group>"; };
 		22F7331C259B71C400956847 /* TOCropViewControllerExample-Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "TOCropViewControllerExample-Extension.entitlements"; sourceTree = "<group>"; };
 		2F5062DC1F53E2D900AA9F14 /* TOCropViewControllerExample-Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "TOCropViewControllerExample-Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		39381CBC2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOCropViewControllerAspectRatioPreset.h; sourceTree = "<group>"; };
+		39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOCropViewControllerAspectRatioPreset.m; sourceTree = "<group>"; };
 		3AADDE231CA5C43400AE0129 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/TOCropViewControllerLocalizable.strings; sourceTree = "<group>"; };
 		6AE313501C47DAA200894C5B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		6AE313511C47DAA200894C5B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/TOCropViewControllerLocalizable.strings; sourceTree = "<group>"; };
@@ -459,6 +468,8 @@
 		22DB4D881B234D07008B8466 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				39381CBC2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h */,
+				39381CBD2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m */,
 				22DB4D891B234D07008B8466 /* TOCropViewControllerTransitioning.h */,
 				22DB4D8A1B234D07008B8466 /* TOCropViewControllerTransitioning.m */,
 				22DB4D9C1B234D4F008B8466 /* TOActivityCroppedImageProvider.h */,
@@ -492,6 +503,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2238CF451FC02AE00081B957 /* TOCropViewController.h in Headers */,
+				39381CC02DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h in Headers */,
 				144B8CD71D22CD650085D774 /* TOCropToolbar.h in Headers */,
 				220C8EB22106344D00A9B25D /* UIImage+CropRotate.h in Headers */,
 				144B8CD81D22CD650085D774 /* TOCropView.h in Headers */,
@@ -512,6 +524,7 @@
 				04262DA220F6FC4600024177 /* TOCropToolbar.h in Headers */,
 				04262DA320F6FC4600024177 /* TOCropView.h in Headers */,
 				04262DA420F6FC4600024177 /* TOCropViewController.h in Headers */,
+				39381CC32DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.h in Headers */,
 				220C8EA82106341600A9B25D /* TOCropViewConstants.h in Headers */,
 				220C8EB12106344D00A9B25D /* UIImage+CropRotate.h in Headers */,
 				04262D9C20F6FC4600024177 /* TOCropViewControllerTransitioning.h in Headers */,
@@ -792,6 +805,7 @@
 			files = (
 				220C8EAD2106344D00A9B25D /* UIImage+CropRotate.m in Sources */,
 				144B8CDA1D22CD730085D774 /* TOCropViewControllerTransitioning.m in Sources */,
+				39381CC12DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */,
 				144B8CDB1D22CD730085D774 /* TOActivityCroppedImageProvider.m in Sources */,
 				144B8CDC1D22CD730085D774 /* TOCroppedImageAttributes.m in Sources */,
 				144B8CDE1D22CD730085D774 /* TOCropOverlayView.m in Sources */,
@@ -817,6 +831,7 @@
 				22DB4D9B1B234D07008B8466 /* TOCropView.m in Sources */,
 				223424761ABBC0CD00BBC2B1 /* ViewController.m in Sources */,
 				22BF96201B2CD017009F4785 /* TOCroppedImageAttributes.m in Sources */,
+				39381CBE2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */,
 				22DB4D9A1B234D07008B8466 /* TOCropToolbar.m in Sources */,
 				223424731ABBC0CD00BBC2B1 /* AppDelegate.m in Sources */,
 				223424701ABBC0CD00BBC2B1 /* main.m in Sources */,
@@ -836,6 +851,7 @@
 				22B68F951FFB380700601B1A /* TOCropViewControllerTransitioning.m in Sources */,
 				22B68F961FFB380700601B1A /* TOActivityCroppedImageProvider.m in Sources */,
 				22B68F971FFB380700601B1A /* TOCroppedImageAttributes.m in Sources */,
+				39381CC42DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */,
 				22B68F991FFB380700601B1A /* TOCropOverlayView.m in Sources */,
 				22B68F9A1FFB380700601B1A /* TOCropScrollView.m in Sources */,
 				22B68F9B1FFB380700601B1A /* TOCropToolbar.m in Sources */,
@@ -858,6 +874,7 @@
 				22B68FA11FFB3C0800601B1A /* TOCroppedImageAttributes.m in Sources */,
 				22B68FA31FFB3C0800601B1A /* TOCropOverlayView.m in Sources */,
 				22B68FA41FFB3C0800601B1A /* TOCropScrollView.m in Sources */,
+				39381CC22DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */,
 				22B68FA51FFB3C0800601B1A /* TOCropToolbar.m in Sources */,
 				22B68FA61FFB3C0800601B1A /* TOCropView.m in Sources */,
 				22B68FA71FFB3C0800601B1A /* TOCropViewController.m in Sources */,
@@ -879,6 +896,7 @@
 				2F5062F01F53E31F00AA9F14 /* TOCropScrollView.m in Sources */,
 				2F5062EB1F53E31F00AA9F14 /* TOCropViewControllerTransitioning.m in Sources */,
 				2F5062ED1F53E31F00AA9F14 /* TOCroppedImageAttributes.m in Sources */,
+				39381CBF2DBA510600F42969 /* TOCropViewControllerAspectRatioPreset.m in Sources */,
 				220C8EB02106344D00A9B25D /* UIImage+CropRotate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Now it's possible to use completely custom aspect ratio presets:
```
    cropViewController.allowedAspectRatios = [
        .init(size: CGSize(width: 1024, height: 768).normalized(), title: "Landscape"),
        .init(size: CGSize(width: 768, height: 1024).normalized(), title: "Portrait"),
    ]
```

Don't forget that aspect ratios need to be normalized (i.e., the `width` and `height` of the size should be in the range `[0..1]`).

```
private extension CGSize {
    func normalized() -> CGSize {
        if width == height {
            CGSize(width: 1, height: 1)
        } else if width > height {
            CGSize(width: 1, height: height / width)
        } else {
            CGSize(width: width / height, height: 1)
        }
    }
}
```