### PR TITLE
Fixed toolbar icon layout issue in iOS 26

### DIFF
--- a/Objective-C/TOCropViewController/Views/TOCropToolbar.m
+++ b/Objective-C/TOCropViewController/Views/TOCropToolbar.m
@@ -294,7 +294,7 @@
         
         for (NSInteger i = 0; i < count; i++) {
             UIButton *button = buttons[i];
-            CGFloat sameOffset = horizontally ? fabs(CGRectGetHeight(containerRect)-CGRectGetHeight(button.bounds)) : fabs(CGRectGetWidth(containerRect)-CGRectGetWidth(button.bounds));
+            CGFloat sameOffset = horizontally ? fabs(CGRectGetHeight(containerRect)-44.0f) : fabs(CGRectGetWidth(containerRect)-CGRectGetWidth(button.bounds));
             CGFloat diffOffset = padding + i * (fixedSize + padding);
             CGPoint origin = horizontally ? CGPointMake(diffOffset, sameOffset) : CGPointMake(sameOffset, diffOffset);
             if (horizontally) {


### PR DESCRIPTION
It looks like `button.bounds` changed between iOS 18 and iOS 26 and this is what was causing the layout issue.

The icons were always 44x44 in size, and so I've unblocked it for now by hardcoding the size.

This fixes the issue, but the library will definitely need a bit of a redesign to look native on iOS 26.