### PR TITLE
Bump minimum OS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "TOCropViewController",
     defaultLocalization: "en",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(
             name: "TOCropViewController",


### PR DESCRIPTION
The `Package.swift` file had a minimum OS version of iOS 11, but Xcode 26 requires a min OS version not less than iOS 12.

Having created this PR, I see there is already an issue (https://github.com/TimOliver/TOCropViewController/issues/615) for this. So, if you’ve already tackled this, please disregard this PR.