### PR TITLE
Fix the insetting of the crop view with top toolbars

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -423,7 +423,11 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
         if (!self.verticalLayout) {
             insets.left = CGRectGetMaxX(self.toolbar.frame);
         } else {
-            insets.bottom = CGRectGetHeight(self.view.frame) - CGRectGetMinY(self.toolbar.frame);
+            if (self.toolbarPosition == TOCropViewControllerToolbarPositionTop) {
+                insets.top = CGRectGetMinY(self.toolbar.frame);
+            } else {
+                insets.bottom = CGRectGetHeight(self.view.frame) - CGRectGetMinY(self.toolbar.frame);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #622 where the insetting calcs were broken when the toolbar is positioned along the top. Sorry about that!
