### PR TITLE
Add callbacks for when the Done button is tapped

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.h
+++ b/Objective-C/TOCropViewController/TOCropViewController.h
@@ -318,6 +318,11 @@
 @property (nullable, nonatomic, strong) NSArray<TOCropViewControllerAspectRatioPreset *> *allowedAspectRatios;
 
 /**
+ Called when the user hits the Done button.
+*/
+@property (nullable, nonatomic, copy) void (^onDidTapDone)(void);
+
+/**
  When the user hits cancel, or completes a
  UIActivityViewController operation, this block will be called,
  giving you a chance to manually dismiss the view controller

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -894,6 +894,12 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     CGRect cropFrame = self.cropView.imageCropFrame;
     NSInteger angle = self.cropView.angle;
 
+    if (self.onDidTapDone) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.onDidTapDone();
+        });
+    }
+
     // If desired, when the user taps done, show an activity sheet
     if (self.showActivitySheetOnDone) {
         TOActivityCroppedImageProvider *imageItem = [[TOActivityCroppedImageProvider alloc] initWithImage:self.image cropFrame:cropFrame angle:angle circular:(self.croppingStyle == TOCropViewCroppingStyleCircular)];

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -45,6 +45,11 @@ public typealias CropViewCroppingStyle = TOCropViewCroppingStyle
 
 @MainActor @objc public protocol CropViewControllerDelegate: NSObjectProtocol {
     /**
+     Called when the user hits the Done button.
+     */
+    @objc optional func cropViewControllerDidTapDone(_ cropViewController: CropViewController)
+
+    /**
      Called when the user has committed the crop action, and provides
      just the cropping rectangle.
      
@@ -319,7 +324,15 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
         set { toCropViewController.allowedAspectRatios = newValue }
         get { return toCropViewController.allowedAspectRatios }
     }
-    
+
+    /**
+     Called when the user hits the Done button.
+     */
+     public var onDidTapDone: (() -> Void)? {
+        set { toCropViewController.onDidTapDone = newValue }
+        get { return toCropViewController.onDidTapDone }
+    }
+
     /**
      When the user hits cancel, or completes a
      UIActivityViewController operation, this block will be called,
@@ -650,13 +663,21 @@ extension CropViewController {
     
     fileprivate func setUpDelegateHandlers() {
         guard let delegate = self.delegate else {
+            onDidTapDone = nil
             onDidCropToRect = nil
             onDidCropImageToRect = nil
             onDidCropToCircleImage = nil
             onDidFinishCancelled = nil
             return
         }
-        
+
+        if delegate.responds(to: #selector((any CropViewControllerDelegate).cropViewControllerDidTapDone(_:))) {
+            self.onDidTapDone = { [weak self] in
+                guard let self else { return }
+                delegate.cropViewControllerDidTapDone?(self)
+            }
+        }
+
         if delegate.responds(to: #selector((any CropViewControllerDelegate).cropViewController(_:didCropImageToRect:angle:))) {
             self.onDidCropImageToRect = {[weak self] rect, angle in
                 guard let strongSelf = self else { return }


### PR DESCRIPTION
This PR adds a delegate method and completion handler that are called when the Done button is tapped. This is useful for displaying an activity indicator or HUD while the newly cropped image is being created (as this can sometimes take a second or two with large images), or for tracking button tap analytics.

![Simulator Screen Recording](https://github.com/user-attachments/assets/86662aca-55d9-4725-8e41-541067f1d545)

### Example Usage (Delegate)
```swift
func cropViewControllerDidTapDone(_ cropViewController: CropViewController) {
    // show activity indicator
}

func cropViewController(_ cropViewController: CropViewController, didCropToImage image: UIImage, withRect cropRect: CGRect, angle: Int) {
    // hide activity indicator
}
```

### Example Usage (Completion Handler)
```swift
cropViewController.onDidTapDone = {
    // show activity indicator
}

cropViewController.onDidCropToRect = { image, cropRect, angle in
    // hide activity indicator
}
```


