### PR TITLE
Add back in common aspect ratio presets

### DIFF
--- a/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.h
+++ b/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.h
@@ -30,6 +30,30 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGSize size;
 @property (nonatomic, readonly) NSString *title;
 
+/// The original aspect ratio of the image (CGSizeZero)
+@property (class, nonatomic, readonly) CGSize original;
+
+/// A square aspect ratio (1:1)
+@property (class, nonatomic, readonly) CGSize square;
+
+/// A 3:2 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio3x2;
+
+/// A 5:3 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio5x3;
+
+/// A 4:3 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio4x3;
+
+/// A 5:4 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio5x4;
+
+/// A 7:5 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio7x5;
+
+/// A 16:9 aspect ratio
+@property (class, nonatomic, readonly) CGSize ratio16x9;
+
 + (NSArray<TOCropViewControllerAspectRatioPreset *> *)portraitPresets;
 + (NSArray<TOCropViewControllerAspectRatioPreset *> *)landscapePresets;
 

--- a/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.m
+++ b/Objective-C/TOCropViewController/Models/TOCropViewControllerAspectRatioPreset.m
@@ -37,6 +37,15 @@
 
 @implementation TOCropViewControllerAspectRatioPreset
 
++ (CGSize)original { return CGSizeZero; }
++ (CGSize)square { return CGSizeMake(1.0f, 1.0f); }
++ (CGSize)ratio3x2 { return CGSizeMake(3.0f, 2.0f); }
++ (CGSize)ratio5x3 { return CGSizeMake(5.0f, 3.0f); }
++ (CGSize)ratio4x3 { return CGSizeMake(4.0f, 3.0f); }
++ (CGSize)ratio5x4 { return CGSizeMake(5.0f, 4.0f); }
++ (CGSize)ratio7x5 { return CGSizeMake(7.0f, 5.0f); }
++ (CGSize)ratio16x9 { return CGSizeMake(16.0f, 9.0f); }
+
 - (instancetype)initWithSize:(CGSize)size title:(NSString *)title {
     self = [super init];
     if (self) {


### PR DESCRIPTION
We moved the aspect ratio settings over to basic `CGSize` in v3.0, but this wasn't a great or intuitive experience. This PR adds back in some of the more common presets as CGSize values to make the experience a little better.