### PR TITLE
Fix Toolbar Layout in Sheet

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -265,6 +265,9 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 }
 
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
+    if (self.navigationController) {
+        return super.preferredScreenEdgesDeferringSystemGestures;
+    }
     return UIRectEdgeAll;
 }
 
@@ -303,33 +306,46 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
             frame.size.height = CGRectGetHeight(self.view.frame);
         }
     } else {
-        // On iOS 26, the safe area insets values are the same, however the default bottom value is so
-        // high that the buttons look incorrectly set. While you can try and hardcode a value lower to
-        // the bottom of the screen, trying to align the width with all the varied corner radii of modern iOS
-        // devices is also difficult.
-
-        // For now, I've decided to use a private API to fetch the corner radius of the device so we can properly align
-        // the toolbar with the device's rounded corners.
-        // I've filed FB20413789 with Apple hoping that this can become a real solution in future.
         if (@available(iOS 26.0, *)) {
-            if (insets.bottom > 0.0f) {
-                insets.bottom = 20.0f;
-            } else {
-                insets.bottom = 8.0f;
+            CGRect frameInWindow = [self.view convertRect:self.view.bounds toView:nil];
+            BOOL isFullscreen = true;
+            if (self.view.window) {
+                isFullscreen = CGRectEqualToRect(frameInWindow, self.view.window.bounds);
             }
+            if (isFullscreen) {
+                // On iOS 26, the safe area insets values are the same, however the default bottom value is so
+                // high that the buttons look incorrectly set. While you can try and hardcode a value lower to
+                // the bottom of the screen, trying to align the width with all the varied corner radii of modern iOS
+                // devices is also difficult.
+
+                // For now, I've decided to use a private API to fetch the corner radius of the device so we can properly align
+                // the toolbar with the device's rounded corners.
+                // I've filed FB20413789 with Apple hoping that this can become a real solution in future.
+                if (insets.bottom > 0.0f) {
+                    insets.bottom = 20.0f;
+                } else {
+                    insets.bottom = 8.0f;
+                }
 
 #if !TARGET_OS_VISION
-            const char *components[] = {"Radius", "Corner", "display", "_"};
-            NSString *selectorName = @"";
-            for (NSInteger i = 3; i >= 0; i--) {
-                selectorName = [selectorName stringByAppendingString:[NSString stringWithCString:components[i]
-                                                                                        encoding:NSUTF8StringEncoding]];
-            }
-            const CGFloat cornerRadius = [[UIScreen.mainScreen valueForKey:selectorName] floatValue];
+                const char *components[] = {"Radius", "Corner", "display", "_"};
+                NSString *selectorName = @"";
+                for (NSInteger i = 3; i >= 0; i--) {
+                    selectorName = [selectorName stringByAppendingString:[NSString stringWithCString:components[i]
+                                                                                            encoding:NSUTF8StringEncoding]];
+                }
+                const CGFloat cornerRadius = [[UIScreen.mainScreen valueForKey:selectorName] floatValue];
 #else
-            const CGFloat cornerRadius = 64.0f;
+                const CGFloat cornerRadius = 64.0f;
 #endif
-            frame.size.width = CGRectGetWidth(self.view.bounds) - MAX(cornerRadius, insets.bottom * 2.0f);
+                frame.size.width = CGRectGetWidth(self.view.bounds) - MAX(cornerRadius, insets.bottom * 2.0f);
+            } else {
+                // Match system toolbar insets
+                insets.left += self.view.layoutMargins.left + 12;
+                insets.right += self.view.layoutMargins.right + 12;
+                insets.bottom = MAX(0, insets.bottom - 6);
+                frame.size.width = CGRectGetWidth(self.view.bounds) - insets.left - insets.right;
+            }
         } else {
             frame.size.width = CGRectGetWidth(self.view.bounds);
         }

--- a/Objective-C/TOCropViewControllerExample/ViewController.m
+++ b/Objective-C/TOCropViewControllerExample/ViewController.m
@@ -211,8 +211,23 @@
                                                               [self presentViewController:profilePicker animated:YES completion:nil];
                                                           }];
 
+    UIAlertAction *cropAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Show Crop in Sheet", @"")
+                                                         style:UIAlertActionStyleDefault
+                                                       handler:^(UIAlertAction *action) {
+
+                                                              TOCropViewController *cropController = [[TOCropViewController alloc] initWithCroppingStyle:self.croppingStyle image:self.image];
+                                                              cropController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+                                                              if (@available(iOS 13.0, *)) {
+                                                                  cropController.modalPresentationStyle = UIModalPresentationAutomatic;
+                                                              }
+                                                              UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:cropController];
+                                                              [self presentViewController:navigationController animated:YES completion:nil];
+                                                          }];
+    [cropAction setEnabled:self.image != nil];
+
     [alertController addAction:defaultAction];
     [alertController addAction:profileAction];
+    [alertController addAction:cropAction];
     [alertController setModalPresentationStyle:UIModalPresentationPopover];
 
     UIPopoverPresentationController *popPresenter = [alertController popoverPresentationController];

--- a/Swift/CropViewController/CropViewController.swift
+++ b/Swift/CropViewController/CropViewController.swift
@@ -490,17 +490,13 @@ open class CropViewController: UIViewController, TOCropViewControllerDelegate {
     open override var childForStatusBarHidden: UIViewController? {
         return toCropViewController
     }
-    
-    open override var prefersStatusBarHidden: Bool {
-        return false
-    }
-    
-    open override var preferredStatusBarStyle: UIStatusBarStyle {
-        return toCropViewController.preferredStatusBarStyle
-    }
-    
-    open override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
-        return toCropViewController.preferredScreenEdgesDeferringSystemGestures
+
+    /**
+     Forward screen edges deferring system gestures changes to the crop view controller
+     :nodoc:
+     */
+    open override var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+        return toCropViewController
     }
     
     // ------------------------------------------------

--- a/Swift/CropViewControllerExample/ViewController.swift
+++ b/Swift/CropViewControllerExample/ViewController.swift
@@ -149,7 +149,7 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
         
         let profileAction = UIAlertAction(title: "Make Profile Picture", style: .default) { (action) in
             self.croppingStyle = .circular
-            
+
             let imagePicker = UIImagePickerController()
             imagePicker.modalPresentationStyle = .popover
             imagePicker.popoverPresentationController?.barButtonItem = (sender as! UIBarButtonItem)
@@ -159,9 +159,22 @@ class ViewController: UIViewController, CropViewControllerDelegate, UIImagePicke
             imagePicker.delegate = self
             self.present(imagePicker, animated: true, completion: nil)
         }
-        
+
+        let cropAction = UIAlertAction(title: "Show Crop in Sheet", style: .default) { (action) in
+
+            let cropViewController = CropViewController(croppingStyle: self.croppingStyle, image: self.image!)
+            cropViewController.modalTransitionStyle = .coverVertical
+            if #available(iOS 13.0, *) {
+                cropViewController.modalPresentationStyle = .automatic
+            }
+            let navigationController = UINavigationController(rootViewController: cropViewController)
+            self.present(navigationController, animated: true, completion: nil)
+        }
+        cropAction.isEnabled = image != nil
+
         alertController.addAction(defaultAction)
         alertController.addAction(profileAction)
+        alertController.addAction(cropAction)
         alertController.modalPresentationStyle = .popover
         
         let presentationController = alertController.popoverPresentationController


### PR DESCRIPTION
Thanks for TOCropViewController! We use it in the [luma.com/ios](https://luma.com/ios). But we found that the placement of the toolbar feels out of place on iOS 26 when presented within a sheet.

Fixes toolbar layout when presented in sheets and other non-fullscreen contexts. Previously, the layout would try to position the toolbar lower than the standard iOS 26 toolbar so the buttons would match the rounded display. But this looks out of place in a non-fullscreen context and in a navigation controller.

Also fixes the forwarding of `preferredScreenEdgesDeferringSystemGestures`, again previously when pushed within a navigations stack it would disable the swipe up to go home gesture.

<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-03 at 15 10 53" src="https://github.com/user-attachments/assets/36621b72-e958-4572-9921-0bdafb8db7c5" />
