### PR TITLE
Make TOCropOverlayView.h public so the grid overlay is visible to Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Mac Catalyst window resizes and iPad split view changes could briefly animate the toolbar into the wrong layout. ([#651](https://github.com/TimOliver/TOCropViewController/pull/651))
 - Toggling `displayHorizontalGridLines`/`displayVerticalGridLines` at runtime now lays out and hides the new grid lines correctly. ([#651](https://github.com/TimOliver/TOCropViewController/pull/651))
 - Setting `rotateCounterclockwiseButtonHidden` didn't lay the toolbar out again, so the hidden button stayed on screen until something else triggered a layout pass. Its setter had been misspelled, and therefore dead, since 2016. ([#651](https://github.com/TimOliver/TOCropViewController/pull/651))
+- `TOCropView.gridOverlayView` was invisible to Swift: `TOCropView.h` only forward-declared `TOCropOverlayView`, and Swift omits properties whose class it knows only as a forward declaration. `TOCropOverlayView.h` is now a public header of both frameworks and is imported rather than forward-declared, so the grid overlay (and its `displayHorizontalGridLines` / `displayVerticalGridLines` settings) can be reached from Swift. ([#653](https://github.com/TimOliver/TOCropViewController/pull/653))
 
 ## Changed
 

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -28,7 +28,15 @@
 #import <TOCropViewController/TOCropViewConstants.h>
 #endif
 
-@class TOCropOverlayView;
+// Imported rather than forward-declared so that `gridOverlayView` has a complete type.
+// Swift omits properties whose class it only knows as a forward declaration, which made
+// the grid overlay unreachable from Swift in every configuration.
+#if !__has_include(<TOCropViewController/TOCropOverlayView.h>)
+#import "TOCropOverlayView.h"
+#else
+#import <TOCropViewController/TOCropOverlayView.h>
+#endif
+
 @class TOCropView;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Swift/CropViewControllerTests/CropViewControllerTests-Bridging-Header.h
+++ b/Swift/CropViewControllerTests/CropViewControllerTests-Bridging-Header.h
@@ -10,7 +10,3 @@
 //
 
 #import "TOCropViewController.h"
-
-// TOCropView.h only forward-declares TOCropOverlayView, and Swift drops properties
-// whose class is incomplete, so `cropView.gridOverlayView` is invisible without this.
-#import "TOCropOverlayView.h"

--- a/TOCropViewControllerExample.xcodeproj/project.pbxproj
+++ b/TOCropViewControllerExample.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		04262D9C20F6FC4600024177 /* TOCropViewControllerTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D891B234D07008B8466 /* TOCropViewControllerTransitioning.h */; };
 		04262D9D20F6FC4600024177 /* TOActivityCroppedImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D9C1B234D4F008B8466 /* TOActivityCroppedImageProvider.h */; };
 		04262D9E20F6FC4600024177 /* TOCroppedImageAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 22BF961E1B2CD017009F4785 /* TOCroppedImageAttributes.h */; };
-		04262DA020F6FC4600024177 /* TOCropOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D8E1B234D07008B8466 /* TOCropOverlayView.h */; };
+		04262DA020F6FC4600024177 /* TOCropOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D8E1B234D07008B8466 /* TOCropOverlayView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04262DA120F6FC4600024177 /* TOCropScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D901B234D07008B8466 /* TOCropScrollView.h */; };
 		04262DA220F6FC4600024177 /* TOCropToolbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D921B234D07008B8466 /* TOCropToolbar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		04262DA320F6FC4600024177 /* TOCropView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D941B234D07008B8466 /* TOCropView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -21,7 +21,7 @@
 		144B8CD11D22CD650085D774 /* TOCropViewControllerTransitioning.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D891B234D07008B8466 /* TOCropViewControllerTransitioning.h */; };
 		144B8CD21D22CD650085D774 /* TOActivityCroppedImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D9C1B234D4F008B8466 /* TOActivityCroppedImageProvider.h */; };
 		144B8CD31D22CD650085D774 /* TOCroppedImageAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 22BF961E1B2CD017009F4785 /* TOCroppedImageAttributes.h */; };
-		144B8CD51D22CD650085D774 /* TOCropOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D8E1B234D07008B8466 /* TOCropOverlayView.h */; };
+		144B8CD51D22CD650085D774 /* TOCropOverlayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D8E1B234D07008B8466 /* TOCropOverlayView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		144B8CD61D22CD650085D774 /* TOCropScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D901B234D07008B8466 /* TOCropScrollView.h */; };
 		144B8CD71D22CD650085D774 /* TOCropToolbar.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D921B234D07008B8466 /* TOCropToolbar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		144B8CD81D22CD650085D774 /* TOCropView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22DB4D941B234D07008B8466 /* TOCropView.h */; settings = {ATTRIBUTES = (Public, ); }; };


### PR DESCRIPTION
`TOCropView.h` declares `gridOverlayView` as a `TOCropOverlayView *`, but only forward-declares that class. Swift omits any property whose class it knows solely as a forward declaration, so **`cropView.gridOverlayView` did not exist from Swift in any configuration** — framework, CocoaPods, or bridging header. That also put the `displayHorizontalGridLines` / `displayVerticalGridLines` settings fixed in 3.2.0 out of reach for Swift callers.

### Why it needed the header to go public

Importing the header from `TOCropView.h` is the fix, but it only works if the header is reachable under the framework's own module. `TOCropOverlayView.h` was marked `Project` in both framework targets, so `<TOCropViewController/TOCropOverlayView.h>` didn't resolve and the Xcode 26 module verifier failed on the quoted fallback.

It's now `Public` in both targets — alongside the other headers `TOCropView.h` already depends on — and imported using the same conditional form already used for `TOCropViewConstants.h`.

### Regression guard

The test bundle's bridging header had been importing `TOCropOverlayView.h` directly to work around this. That workaround is removed, so the existing Swift test is now the guard: reverting the import in `TOCropView.h` makes `CropViewControllerTests.swift` fail to compile with

```
value of type 'TOCropView' has no member 'gridOverlayView'
```

### Verification

- Xcode 26 module verifier passes; the built framework now ships `TOCropOverlayView.h` alongside the other five public headers
- 33 tests pass; all five schemes build
- SPM builds for iOS; both podspecs pass `pod lib lint`
- `clang-format` clean

The changelog entry is filed under 3.2.0, since that hasn't been tagged or pushed to trunk yet. Happy to move it to its own section if you'd rather ship 3.2.0 as-is.